### PR TITLE
Hotfix / patch inhabilito botón Correr algoritmo de fechas

### DIFF
--- a/src/components/Algorithms/Dates.js
+++ b/src/components/Algorithms/Dates.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Alert } from "@mui/material";
 import {
   Grid,
   Box,
@@ -229,7 +230,7 @@ const Dates = () => {
   };
 
   const handleRunAlgorithm = async () => {
-    try {
+    try { 
       setRunning(true);
       setOpenDialog(true);
       setOpenRunDialog(false);
@@ -535,6 +536,31 @@ const Dates = () => {
     }
   };
 
+  const parameters_to_complete = () => {
+   return (
+       <>
+        <DialogContent>
+          <TextField
+            margin="dense"
+            label="Límite máximo en la diferencia"
+            type="number"
+            fullWidth
+            value={maxDifference}
+            onChange={(e) => setMaxDifference(e.target.value)}
+          />
+          <TextField
+            // autoFocus
+            margin="dense"
+            label="Máximo grupos por semana"
+            type="number"
+            fullWidth
+            value={maxGroups}
+            onChange={(e) => setMaxGroups(e.target.value)}
+          />
+        </DialogContent>
+        </>)
+  }
+        
   return (
     <Box sx={{ padding: 3 }}>
       <Grid container spacing={2}>
@@ -765,31 +791,21 @@ const Dates = () => {
           </Button>
         </DialogActions>
       </Dialog>
-
+            
+      
       <Dialog open={openRunDialog} onClose={handleCloseRunDialog}>
-        <DialogTitle>
+
+      <DialogTitle>
           Seleccione la diferencia de grupos entre evaluadores y el límite
           máximo de grupos por semana
         </DialogTitle>
-        <DialogContent>
-          <TextField
-            margin="dense"
-            label="Límite máximo en la diferencia"
-            type="number"
-            fullWidth
-            value={maxDifference}
-            onChange={(e) => setMaxDifference(e.target.value)}
-          />
-          <TextField
-            // autoFocus
-            margin="dense"
-            label="Máximo grupos por semana"
-            type="number"
-            fullWidth
-            value={maxGroups}
-            onChange={(e) => setMaxGroups(e.target.value)}
-          />
-        </DialogContent>
+
+        <Alert severity="error">            
+          {"Esta funcionalidad está en mantenimiento, estará disponible a la brevedad."}
+        </Alert>
+
+        {parameters_to_complete()}
+
         <DialogActions sx={{ padding: "16px 24px" }}>
           <Button
             onClick={handleCloseRunDialog}
@@ -802,6 +818,7 @@ const Dates = () => {
             onClick={handleRunAlgorithm}
             color="primary"
             variant="contained"
+            disabled={true} // HOTFIX: HASTA QUE FUNCIONE LA EJECUCIÓN DEL ALGORITMO DE FECHAS
           >
             Correr
           </Button>


### PR DESCRIPTION
**Inhabilito el botón para correr el algoritmo de fechas y pongo un cartel informando** que la funcionalidad está en mantenimiento y no se puede usar por ahora, **para que no se rompa el server prod del back** por intentar ejecutarlo. Adjunto screen abajo, se puede ver que el borón está gris y hay un cartel avisando.

Esto es un **parche** hasta que solucionemos el problema de fondo y se pueda ejecutar correctamente el algoritmo.

Lo mergearía directamente a main para usarlo en producción, y quizás no a staging para que sí podamos ejecutar el algoritmo en el entorno de staging. (Entorno de staging front está en progreso, ok mergéenlo a donde les guste pero **que llegue a prod :))**.

![Captura desde 2025-06-18 21-40-11](https://github.com/user-attachments/assets/15419477-c3b0-48ec-91e1-1779d92673b6)
