### PR TITLE
Feat/editar estudiantes tutores temas y su refactor menos lag

### DIFF
--- a/src/api/handleStudents.js
+++ b/src/api/handleStudents.js
@@ -85,3 +85,20 @@ export const addStudent = async (newStudent, user, period_id) => {
         throw new Error(err);
     }
 };
+
+export const editStudent = async (original_student_id, period_id, studentToEdit, user) => {
+  const config = {
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+      },
+    };
+  
+  try {
+      const url = `${BASE_URL}/students/${original_student_id}/periods/${period_id}`;
+      const response = await axios.patch(url, studentToEdit, config);
+      return response.data;
+  } catch (err) {
+      console.error(`Error when editing student: ${err}`)
+      throw new Error(err);
+  }
+};

--- a/src/api/handleTopics.js
+++ b/src/api/handleTopics.js
@@ -29,3 +29,31 @@ export const addTopic = async (newTopic, user, period_id) => {
         throw new Error(err);
     }
 };
+
+// En el caso de los temas, el id no es editable (no resulta de relevancia en el domino).
+// Solo se usa para identificar unívocamente al tema.
+export const editTopic = async (id, period_id, topicToEdit, user) => {
+  const config = {
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+      },
+    };
+
+  // Con esto enviamos Exactamente los campos que el back espera (y excluimos el id, que ya está
+  // como path param)
+  const sendableTopicToEdit = {
+    "name": topicToEdit.name,
+    "category": topicToEdit.category,
+    "tutor_email": topicToEdit.tutor_email,
+    "capacity": topicToEdit.capacity
+  };
+  
+  try {
+      const url = `${BASE_URL}/topics/${id}/periods/${period_id}`;
+      const response = await axios.patch(url, sendableTopicToEdit, config);
+      return response.data;
+  } catch (err) {
+      console.error(`Error when editing student: ${err}`)
+      throw new Error(err);
+  }
+};

--- a/src/api/handleTutors.js
+++ b/src/api/handleTutors.js
@@ -33,10 +33,20 @@ export const editTutor = async (original_tutor_id, period_id, tutorToEdit, user)
         Authorization: `Bearer ${user.token}`,
       },
     };
-  
+
+    // Esto es necesario porque, si no, el ítem tutor tiene más campos (como tutor_periods)
+    // que el back No espera.
+    const sendableTutorToEdit = {
+      "id": tutorToEdit.id,
+      "name": tutorToEdit.name,
+      "last_name": tutorToEdit.last_name,
+      "email": tutorToEdit.email,
+      "capacity": tutorToEdit.capacity
+    };
   try {
       const url = `${BASE_URL}/tutors/${original_tutor_id}/periods/${period_id}`;
-      const response = await axios.patch(url, tutorToEdit, config);
+      const response = await axios.patch(url, sendableTutorToEdit, config);
+
       return response.data;
   } catch (err) {
       console.error(`Error when editing tutor: ${err}`)

--- a/src/api/handleTutors.js
+++ b/src/api/handleTutors.js
@@ -26,3 +26,20 @@ export const addTutor = async (newTutor, user, period) => {
     throw new Error(err);
   }
 };
+
+export const editTutor = async (original_tutor_id, period_id, tutorToEdit, user) => {
+  const config = {
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+      },
+    };
+  
+  try {
+      const url = `${BASE_URL}/tutors/${original_tutor_id}/periods/${period_id}`;
+      const response = await axios.patch(url, tutorToEdit, config);
+      return response.data;
+  } catch (err) {
+      console.error(`Error when editing tutor: ${err}`)
+      throw new Error(err);
+  }
+};

--- a/src/components/UI/Tables/ChildTables/StudentsTable.js
+++ b/src/components/UI/Tables/ChildTables/StudentsTable.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { TableCell } from '@mui/material';
 import ParentTable from '../ParentTable';
 import { useSelector } from "react-redux";
+import { TableType } from '../TableType';
 
 const StudentsTable = () => {
   const period = useSelector((state) => state.period);
   const endpoint = `/students/?period=${period.id}`; // Replace with your endpoint
-  const title = 'Alumnos';
+  const title = TableType.STUDENTS;
   const columns = ['Padron', 'Nombre', 'Apellido', 'Email']; // Specify your column names here
   const rowKeys = {
     'Padron': 'id',

--- a/src/components/UI/Tables/ChildTables/TopicsTable.js
+++ b/src/components/UI/Tables/ChildTables/TopicsTable.js
@@ -2,12 +2,13 @@ import React from 'react';
 import ParentTable from '../ParentTable';
 import { TableCell } from '@mui/material';
 import { useSelector } from 'react-redux';
+import { TableType } from '../TableType';
 
 const TopicsTable = () => {
   const period = useSelector((state) => state.period);
 
   const endpoint = `/topics/?period=${period.id}`; 
-  const title = 'Temas';
+  const title = TableType.TOPICS;
   const columns = ['ID', 'Tema', 'Categoría'];
   const rowKeys = {
     'ID': 'id',

--- a/src/components/UI/Tables/ChildTables/TutorsTable.js
+++ b/src/components/UI/Tables/ChildTables/TutorsTable.js
@@ -4,6 +4,7 @@ import { TableCell } from '@mui/material';
 import { useParams } from 'react-router';
 import { useSelector } from "react-redux";
 import { TableType } from '../TableType';
+import { addCapacityToTutors } from '../../../../utils/addCapacityToTutors';
 
 const TutorsTable = () => {
   const { period } = useParams();
@@ -18,19 +19,11 @@ const TutorsTable = () => {
     'Email': 'email'
   };
 
-  const tutors = Object.values(useSelector((state) => state.tutors))
+  const tutorsWithoutCapacityField = Object.values(useSelector((state) => state.tutors))
   .map(({ version, rehydrated, ...rest }) => rest)
-  .filter(item => Object.keys(item).length > 0)
-  .map((item) => {
-    const selectedTutorPeriod = item.tutor_periods.find(tp => tp.period_id === period.id);
-    const capacity = selectedTutorPeriod ? selectedTutorPeriod.capacity : null;
-    return {...item, capacity};
-  });
+  .filter(item => Object.keys(item).length > 0);
+  const tutors = addCapacityToTutors(tutorsWithoutCapacityField, period);
   console.log("TUTORS desde su table:", tutors);
-
-  // const selectedTutorPeriod = item.tutor_periods.find(tp => tp.period_id === period.id);
-  //     const capacity = selectedTutorPeriod ? selectedTutorPeriod.capacity : null;
-  //     item["capacity"]=capacity;
 
   const renderRow = (item) => (
     <>

--- a/src/components/UI/Tables/ChildTables/TutorsTable.js
+++ b/src/components/UI/Tables/ChildTables/TutorsTable.js
@@ -20,7 +20,13 @@ const TutorsTable = () => {
 
   const tutors = Object.values(useSelector((state) => state.tutors))
   .map(({ version, rehydrated, ...rest }) => rest)
-  .filter(item => Object.keys(item).length > 0);
+  .filter(item => Object.keys(item).length > 0)
+  .map((item) => {
+    const selectedTutorPeriod = item.tutor_periods.find(tp => tp.period_id === period.id);
+    const capacity = selectedTutorPeriod ? selectedTutorPeriod.capacity : null;
+    return {...item, capacity};
+  });
+  console.log("TUTORS desde su table:", tutors);
 
   // const selectedTutorPeriod = item.tutor_periods.find(tp => tp.period_id === period.id);
   //     const capacity = selectedTutorPeriod ? selectedTutorPeriod.capacity : null;

--- a/src/components/UI/Tables/ChildTables/TutorsTable.js
+++ b/src/components/UI/Tables/ChildTables/TutorsTable.js
@@ -23,7 +23,6 @@ const TutorsTable = () => {
   .map(({ version, rehydrated, ...rest }) => rest)
   .filter(item => Object.keys(item).length > 0);
   const tutors = addCapacityToTutors(tutorsWithoutCapacityField, period);
-  console.log("TUTORS desde su table:", tutors);
 
   const renderRow = (item) => (
     <>

--- a/src/components/UI/Tables/ChildTables/TutorsTable.js
+++ b/src/components/UI/Tables/ChildTables/TutorsTable.js
@@ -3,11 +3,12 @@ import ParentTable from '../ParentTable';
 import { TableCell } from '@mui/material';
 import { useParams } from 'react-router';
 import { useSelector } from "react-redux";
+import { TableType } from '../TableType';
 
 const TutorsTable = () => {
   const { period } = useParams();
   const endpoint = `/tutors/periods/${period}`;
-  const title = 'Tutores';
+  const title = TableType.TUTORS;
   
   const columns = ['ID', 'Nombre', 'Apellido', 'Email'];
   const rowKeys = {

--- a/src/components/UI/Tables/ChildTables/TutorsTable.js
+++ b/src/components/UI/Tables/ChildTables/TutorsTable.js
@@ -22,6 +22,10 @@ const TutorsTable = () => {
   .map(({ version, rehydrated, ...rest }) => rest)
   .filter(item => Object.keys(item).length > 0);
 
+  // const selectedTutorPeriod = item.tutor_periods.find(tp => tp.period_id === period.id);
+  //     const capacity = selectedTutorPeriod ? selectedTutorPeriod.capacity : null;
+  //     item["capacity"]=capacity;
+
   const renderRow = (item) => (
     <>
       <TableCell>{item.id}</TableCell>

--- a/src/components/UI/Tables/Modals/studentModals.js
+++ b/src/components/UI/Tables/Modals/studentModals.js
@@ -56,62 +56,69 @@ export const StudentModals = ({
             >
               {TitleText} Alumno
             </DialogTitle>
-            <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
-              <NumericFormat
-                fullWidth
-                allowNegative={false}
-                customInput={TextField}
-                variant="outlined"
-                autoFocus
-                margin="normal"
-                label="Padrón"
-                value={item["id"] || ""}
-                required
-                onChange={(e) =>
-                  setItem({ ...item, id: parseInt(e.target.value) })
-                }
-              />
-              <TextField
-                variant="outlined"
-                fullWidth
-                margin="normal"
-                label="Nombre"
-                value={item["name"] || ""}
-                required
-                onChange={(e) => setItem({ ...item, name: e.target.value })}
-              />
-              <TextField
-                variant="outlined"
-                fullWidth
-                margin="normal"
-                label="Apellido"
-                value={item["last_name"] || ""}
-                required
-                onChange={(e) =>
-                  setItem({ ...item, last_name: e.target.value })
-                }
-              />
-              <TextField
-                label="Email"
-                type="email"
-                fullWidth
-                margin="normal"
-                variant="outlined"
-                value={item["email"] || ""}
-                onChange={(e) =>
-                  setItem({ ...item, email: e.target.value })
-                }
-                required
-              />
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={handleCloseModal} variant="outlined" color="error">
-                Cancelar
-              </Button>
-              <Button onClick={() => handleConfirmAction(item, setItem, handleCloseModal)} variant="contained" color="primary">
-                {ConfirmButtonText}
-              </Button>
-            </DialogActions>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault(); // previene el reload del form
+                handleConfirmAction(item, setItem, handleCloseModal);
+              }}
+            >
+              <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
+                <NumericFormat
+                  fullWidth
+                  allowNegative={false}
+                  customInput={TextField}
+                  variant="outlined"
+                  autoFocus
+                  margin="normal"
+                  label="Padrón"
+                  value={item["id"] || ""}
+                  required
+                  onChange={(e) =>
+                    setItem({ ...item, id: parseInt(e.target.value) })
+                  }
+                />
+                <TextField
+                  variant="outlined"
+                  fullWidth
+                  margin="normal"
+                  label="Nombre"
+                  value={item["name"] || ""}
+                  required
+                  onChange={(e) => setItem({ ...item, name: e.target.value })}
+                />
+                <TextField
+                  variant="outlined"
+                  fullWidth
+                  margin="normal"
+                  label="Apellido"
+                  value={item["last_name"] || ""}
+                  required
+                  onChange={(e) =>
+                    setItem({ ...item, last_name: e.target.value })
+                  }
+                />
+                <TextField
+                  label="Email"
+                  type="email"
+                  fullWidth
+                  margin="normal"
+                  variant="outlined"
+                  value={item["email"] || ""}
+                  onChange={(e) =>
+                    setItem({ ...item, email: e.target.value })
+                  }
+                  required
+                />
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={handleCloseModal} variant="outlined" color="error">
+                  Cancelar
+                </Button>
+                <Button type="submit" variant="contained" color="primary">
+                  {ConfirmButtonText}
+                </Button>
+              </DialogActions>
+            </form>
           </Dialog>
         )
       };

--- a/src/components/UI/Tables/Modals/studentModals.js
+++ b/src/components/UI/Tables/Modals/studentModals.js
@@ -1,0 +1,142 @@
+// const [openAddModal, setOpenAddModal] = useState(false);
+// const [openEditModal, setOpenEditModal] = useState(false);
+import React, { useEffect, useState } from "react";
+import {
+  Button,
+  TextField,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from "@mui/material";
+import { NumericFormat } from "react-number-format";
+
+export const StudentModals = ({
+  openAddModal, // bools para ver si se debe abrir cada modal
+  openEditModal,
+  setOpenAddModal, // necesarias para cerrar los modals
+  setOpenEditModal,
+  handleAddItem, // las acciones al clickear confirmar desde cada modal
+  handleEditItem,
+  originalEditedItemId, // para pasárselo a la función que habla con la api al confirmar _ no, ya lo tiene si se crea afuera. Necesito su set si debo tener acá ese handle.
+  setOriginalEditedItemId
+  
+}) => {
+  
+      const [newItem, setNewItem] = useState({});
+      const [editedItem, setEditedItem] = useState({}); // data
+      
+      ///// Estos handles podrían ir en otro lado /////
+      const handleClickOpenAddModal = () => {
+          setOpenAddModal(true);
+      };
+      
+      const handleClickOpenEditModal = (item) => {
+          // El id puede cambiar, así que guardamos el id original
+          setOriginalEditedItemId(item.id);
+          setEditedItem(item);
+          setOpenEditModal(true);    
+      };
+
+      const handleCloseAddModal = () => {
+          setNewItem({})
+          setOpenAddModal(false);
+      };
+      
+      const handleCloseEditModal = () => {
+          setEditedItem({})
+          setOpenEditModal(false);
+      };
+
+      /////// Modals de Estudiante ///////
+      const innerActionStudentModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {    
+        // y si pongo el set acá?
+        setEditedItem(item); // éste es el set complicado xq se crea acá adentro
+        setOriginalEditedItemId(item.id);
+        return (
+          <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
+            <DialogTitle
+              sx={{
+                fontWeight: "bold",
+                textAlign: "center",
+                backgroundColor: "#f5f5f5",
+                color: "#333",
+                padding: "16px 24px",
+              }}
+            >
+              {TitleText} Alumno
+            </DialogTitle>
+            <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
+              <NumericFormat
+                fullWidth
+                allowNegative={false}
+                customInput={TextField}
+                variant="outlined"
+                autoFocus
+                margin="normal"
+                label="Padrón"
+                value={item["id"] || ""}
+                required
+                onChange={(e) =>
+                  setItem({ ...item, id: parseInt(e.target.value) })
+                }
+              />
+              <TextField
+                variant="outlined"
+                fullWidth
+                margin="normal"
+                label="Nombre"
+                value={item["name"] || ""}
+                required
+                onChange={(e) => setItem({ ...item, name: e.target.value })}
+              />
+              <TextField
+                variant="outlined"
+                fullWidth
+                margin="normal"
+                label="Apellido"
+                value={item["last_name"] || ""}
+                required
+                onChange={(e) =>
+                  setItem({ ...item, last_name: e.target.value })
+                }
+              />
+              <TextField
+                label="Email"
+                type="email"
+                fullWidth
+                margin="normal"
+                variant="outlined"
+                value={item["email"] || ""}
+                onChange={(e) =>
+                  setItem({ ...item, email: e.target.value })
+                }
+                required
+              />
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleCloseModal} variant="outlined" color="error">
+                Cancelar
+              </Button>
+              <Button onClick={() => handleConfirmAction(item, setItem, handleCloseModal)} variant="contained" color="primary">
+                {ConfirmButtonText}
+              </Button>
+            </DialogActions>
+          </Dialog>
+        )
+      };
+
+      // const addStudentModal = () => {
+      //   return innerActionStudentModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Agregar")
+      // }
+    
+      // const editStudentModal = () => {
+      //   return innerActionStudentModal(openEditModal, handleCloseEditModal, handleEdit, editedItem, setEditedItem, "Editar", "Guardar")
+      // }
+  return (
+    <>
+      {innerActionStudentModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Agregar")};
+      {innerActionStudentModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")};
+    </>
+  )
+}

--- a/src/components/UI/Tables/Modals/studentModals.js
+++ b/src/components/UI/Tables/Modals/studentModals.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {
   Button,
   TextField,
@@ -8,6 +8,7 @@ import {
   DialogActions,
 } from "@mui/material";
 import { NumericFormat } from "react-number-format";
+import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
 
 export const StudentModals = ({
   openAddModal, // bools para ver si se debe abrir cada modal
@@ -22,41 +23,23 @@ export const StudentModals = ({
   setParentItem
   
 }) => {
-  
-      const [newItem, setNewItem] = useState({});
-      const [editedItem, setEditedItem] = useState({}); // data
-      
-      // Esto hace de handle open edit (para add no es nec xq solo se setea un bool)
-      useEffect(() => {
-        if (!openEditModal) return;
 
-        setEditedItem(item); // éste es el set complicado xq se crea acá adentro
-        setOriginalEditedItemId(item.id);        
-
-      }, [openEditModal, item]);
-      ///// Estos handles podrían ir en otro lado /////
-      const handleClickOpenAddModal = () => {
-          setOpenAddModal(true);
-      };
-      
-      const handleClickOpenEditModal = (item) => {
-          // El id puede cambiar, así que guardamos el id original
-          setOriginalEditedItemId(item.id);
-          setEditedItem(item);
-          setOpenEditModal(true);    
-      };
-
-      const handleCloseAddModal = () => {
-          setNewItem({})
-          setOpenAddModal(false);
-          setParentItem(false);
-      };
-      
-      const handleCloseEditModal = () => {
-          setEditedItem({})
-          setOpenEditModal(false);
-          setParentItem(false);
-      };
+      // Creo los estados, gestiono handle open, y obtengo los handle close.
+      const {
+        newItem,
+        setNewItem,
+        editedItem,
+        setEditedItem,
+        handleCloseAddModal,
+        handleCloseEditModal
+      } = useOpenCloseStateModalLogic({
+          openEditModal,
+          item,
+          setOpenAddModal,
+          setOpenEditModal,
+          setOriginalEditedItemId,
+          setParentItem
+      });
 
       /////// Modals de Estudiante ///////
       const innerActionStudentModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {    
@@ -133,17 +116,18 @@ export const StudentModals = ({
         )
       };
 
-      // const addStudentModal = () => {
-      //   return innerActionStudentModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Agregar")
-      // }
+      const addStudentModal = () => {
+        return innerActionStudentModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Agregar")
+      }
     
-      // const editStudentModal = () => {
-      //   return innerActionStudentModal(openEditModal, handleCloseEditModal, handleEdit, editedItem, setEditedItem, "Editar", "Guardar")
-      // }
+      const editStudentModal = () => {
+        return innerActionStudentModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")
+      }
+
   return (
     <>
-      {innerActionStudentModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Agregar")};
-      {innerActionStudentModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")};
+      {addStudentModal()};
+      {editStudentModal()};
     </>
   )
 }

--- a/src/components/UI/Tables/Modals/studentModals.js
+++ b/src/components/UI/Tables/Modals/studentModals.js
@@ -19,13 +19,23 @@ export const StudentModals = ({
   handleAddItem, // las acciones al clickear confirmar desde cada modal
   handleEditItem,
   originalEditedItemId, // para pasárselo a la función que habla con la api al confirmar _ no, ya lo tiene si se crea afuera. Necesito su set si debo tener acá ese handle.
-  setOriginalEditedItemId
+  setOriginalEditedItemId,
+  item,
+  setParentItem
   
 }) => {
   
       const [newItem, setNewItem] = useState({});
       const [editedItem, setEditedItem] = useState({}); // data
       
+      // Esto hace de handle open edit (para add no es nec xq solo se setea un bool)
+      useEffect(() => {
+        if (!openEditModal) return;
+
+        setEditedItem(item); // éste es el set complicado xq se crea acá adentro
+        setOriginalEditedItemId(item.id);        
+
+      }, [openEditModal, item]);
       ///// Estos handles podrían ir en otro lado /////
       const handleClickOpenAddModal = () => {
           setOpenAddModal(true);
@@ -41,18 +51,20 @@ export const StudentModals = ({
       const handleCloseAddModal = () => {
           setNewItem({})
           setOpenAddModal(false);
+          setParentItem(false);
       };
       
       const handleCloseEditModal = () => {
           setEditedItem({})
           setOpenEditModal(false);
+          setParentItem(false);
       };
 
       /////// Modals de Estudiante ///////
       const innerActionStudentModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {    
         // y si pongo el set acá?
-        setEditedItem(item); // éste es el set complicado xq se crea acá adentro
-        setOriginalEditedItemId(item.id);
+        // setEditedItem(item); // éste es el set complicado xq se crea acá adentro
+        // setOriginalEditedItemId(item.id);
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
             <DialogTitle

--- a/src/components/UI/Tables/Modals/studentModals.js
+++ b/src/components/UI/Tables/Modals/studentModals.js
@@ -10,6 +10,7 @@ import {
 import { NumericFormat } from "react-number-format";
 import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
 
+/* Modals para Agregar y Editar un/a estudiante */
 export const StudentModals = ({
   openAddModal, // bools para ver si se debe abrir cada modal
   openEditModal,
@@ -17,7 +18,7 @@ export const StudentModals = ({
   setOpenEditModal,
   handleAddItem, // las acciones al clickear confirmar desde cada modal
   handleEditItem,
-  originalEditedItemId, // para pasárselo a la función que habla con la api al confirmar _ no, ya lo tiene si se crea afuera. Necesito su set si debo tener acá ese handle.
+  originalEditedItemId, // para pasárselo a la función que habla con la api al confirmar, y su set para el handle
   setOriginalEditedItemId,
   item, // recibido del parent, y su set para flushearlo al salir
   setParentItem

--- a/src/components/UI/Tables/Modals/studentModals.js
+++ b/src/components/UI/Tables/Modals/studentModals.js
@@ -33,12 +33,12 @@ export const StudentModals = ({
         handleCloseAddModal,
         handleCloseEditModal
       } = useOpenCloseStateModalLogic({
-          openEditModal,
-          item,
-          setOpenAddModal,
-          setOpenEditModal,
-          setOriginalEditedItemId,
-          setParentItem
+          openEditModal: openEditModal,
+          item: item,
+          setOpenAddModal: setOpenAddModal,
+          setOpenEditModal: setOpenEditModal,
+          setOriginalEditedItemId: setOriginalEditedItemId,
+          setParentItem: setParentItem
       });
 
       /////// Modals de Estudiante ///////

--- a/src/components/UI/Tables/Modals/studentModals.js
+++ b/src/components/UI/Tables/Modals/studentModals.js
@@ -43,7 +43,7 @@ export const StudentModals = ({
       });
 
       /////// Modals de Estudiante ///////
-      const innerActionStudentModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {    
+      const innerActionStudentModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
             <DialogTitle
@@ -77,6 +77,7 @@ export const StudentModals = ({
                   onChange={(e) =>
                     setItem({ ...item, id: parseInt(e.target.value) })
                   }
+                  disabled={disableEditId}
                 />
                 <TextField
                   variant="outlined"
@@ -129,7 +130,7 @@ export const StudentModals = ({
       }
     
       const editStudentModal = () => {
-        return innerActionStudentModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")
+        return innerActionStudentModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
       }
 
   return (

--- a/src/components/UI/Tables/Modals/topicModals.js
+++ b/src/components/UI/Tables/Modals/topicModals.js
@@ -14,6 +14,7 @@ import {
 import { NumericFormat } from "react-number-format";
 import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
 
+/* Modals para Agregar y Editar un tema */
 export const TopicModals = ({
   openAddModal, // bools para ver si se debe abrir cada modal
   openEditModal,
@@ -21,11 +22,11 @@ export const TopicModals = ({
   setOpenEditModal,
   handleAddItem, // las acciones al clickear confirmar desde cada modal
   handleEditItem,
-  originalEditedItemId, // para pasárselo a la función que habla con la api al confirmar _ no, ya lo tiene si se crea afuera. Necesito su set si debo tener acá ese handle.
+  originalEditedItemId, // para pasárselo a la función que habla con la api al confirmar, y su set para el handle
   setOriginalEditedItemId,
   item, // recibido del parent, y su set para flushearlo al salir
   setParentItem,
-  tutors, // estos dos están temporalmente acá, quizás podría []
+  tutors, // estos dos []
   categories
 
 }) => {

--- a/src/components/UI/Tables/Modals/topicModals.js
+++ b/src/components/UI/Tables/Modals/topicModals.js
@@ -49,7 +49,7 @@ export const TopicModals = ({
     });
 
     /////// Modals de Estudiante ///////   
-    const innerActionTopicModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, titleText, confirmButtonText) => {
+    const innerActionTopicModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, titleText, confirmButtonText, disableBcEndpointDoesNotExistYet=false) => {
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
             <DialogTitle
@@ -144,7 +144,7 @@ export const TopicModals = ({
                 <Button onClick={handleCloseModal} variant="outlined" color="error">
                   Cancelar
                 </Button>
-                <Button type="submit" variant="contained" color="primary">
+                <Button type="submit" disabled={disableBcEndpointDoesNotExistYet} variant="contained" color="primary">
                   {confirmButtonText}
                 </Button>
               </DialogActions>
@@ -157,8 +157,9 @@ export const TopicModals = ({
         return innerActionTopicModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar");
       };
     
+      // Este true del final es solo temporal hasta que exista el endpoint de editar tema.
       const editTopicModal = () => {
-        return innerActionTopicModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")
+        return innerActionTopicModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
       };
 
       return (

--- a/src/components/UI/Tables/Modals/topicModals.js
+++ b/src/components/UI/Tables/Modals/topicModals.js
@@ -1,0 +1,178 @@
+import React, { useEffect, useState } from "react";
+import {
+  Button,
+  TextField,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  //
+  Select,
+  MenuItem,
+  InputLabel
+} from "@mui/material";
+import { NumericFormat } from "react-number-format";
+
+export const TopicModals = ({
+  openAddModal, // bools para ver si se debe abrir cada modal
+  openEditModal,
+  setOpenAddModal, // necesarias para cerrar los modals
+  setOpenEditModal,
+  handleAddItem, // las acciones al clickear confirmar desde cada modal
+  handleEditItem,
+  originalEditedItemId, // para pasárselo a la función que habla con la api al confirmar _ no, ya lo tiene si se crea afuera. Necesito su set si debo tener acá ese handle.
+  setOriginalEditedItemId,
+  item, // recibido del parent, y su set para flushearlo al salir
+  setParentItem,
+  tutors, // estos dos están temporalmente acá, quizás podría []
+  categories
+
+}) => {
+
+    const [newItem, setNewItem] = useState({});
+    const [editedItem, setEditedItem] = useState({}); // data
+
+    // Esto hace de handle open edit (para add no es nec xq solo se setea un bool)
+    useEffect(() => {
+      if (!openEditModal) return;
+
+      setEditedItem(item); // éste es el set complicado xq se crea acá adentro
+      setOriginalEditedItemId(item.id);        
+
+    }, [openEditModal, item]);
+    ///// Estos handles podrían ir en otro lado /////
+    const handleClickOpenAddModal = () => {
+        setOpenAddModal(true);
+    };
+    
+    const handleClickOpenEditModal = (item) => {
+        // El id puede cambiar, así que guardamos el id original
+        setOriginalEditedItemId(item.id);
+        setEditedItem(item);
+        setOpenEditModal(true);    
+    };
+
+    const handleCloseAddModal = () => {
+        setNewItem({})
+        setOpenAddModal(false);
+        setParentItem(false);
+    };
+    
+    const handleCloseEditModal = () => {
+        setEditedItem({})
+        setOpenEditModal(false);
+        setParentItem(false);
+    };
+
+    /////// Modals de Estudiante ///////   
+    const innerActionTopicModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, titleText, confirmButtonText) => {
+        return (
+          <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
+            <DialogTitle
+              sx={{
+                fontWeight: "bold",
+                textAlign: "center",
+                backgroundColor: "#f5f5f5",
+                color: "#333",
+                padding: "16px 24px",
+              }}
+            >
+              {titleText} Tema
+            </DialogTitle>
+            <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
+              <TextField
+                variant="outlined"
+                fullWidth
+                margin="normal"
+                label="Titulo"
+                value={item["name"] || ""}
+                required
+                onChange={(e) => setItem({ ...item, name: e.target.value })}
+              />
+              <InputLabel>Seleccionar categoria</InputLabel>
+              <Select
+                value={
+                  item["category"] || ""
+                }
+                label="Categorías"
+                onChange={(e) =>
+                  setItem({ ...item, category: e.target.value })
+                }
+                margin="normal"
+    
+                sx={{ marginBottom: "8px" }}
+                required
+                fullWidth
+              >
+                <MenuItem key="" value="" disabled>
+                  Seleccionar categoria
+                </MenuItem>
+                {categories.map((category) => (
+                  <MenuItem key={category} value={category}>
+                    {category}
+                  </MenuItem>
+                ))}
+              </Select>
+              <InputLabel margin="normal">Seleccionar tutor</InputLabel>
+              <Select
+                margin="normal"
+                value={
+                  item["tutor_email"] || ""
+                }
+                label="Email del tutor"
+                onChange={(e) =>
+                  setItem({ ...item, tutor_email: e.target.value })
+                }
+                required
+                fullWidth
+              >
+                <MenuItem key="" value="" disabled>
+                  Seleccionar tutor
+                </MenuItem>
+                {tutors.map((tutor) => (
+                  <MenuItem key={tutor.id} value={tutor.email}>
+                    {tutor.email}
+                  </MenuItem>
+                ))}
+              </Select>
+              <NumericFormat
+                fullWidth
+                allowNegative={false}
+                customInput={TextField}
+                variant="outlined"
+                margin="normal"
+                label="Capacidad"
+                value={item["capacity"] || ""}
+                required
+                onChange={(e) =>
+                  setItem({ ...item, capacity: parseInt(e.target.value) })
+                }
+              />
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleCloseModal} variant="outlined" color="error">
+                Cancelar
+              </Button>
+              <Button onClick={() => handleConfirmAction(item, setItem, handleCloseModal)} variant="contained" color="primary">
+                {confirmButtonText}
+              </Button>
+            </DialogActions>
+          </Dialog>
+        )
+      };
+
+    //   const addTopicModal = () => {
+    //     return innerActionTopicModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar");
+    //   };
+    
+    //   const editTopicModal = () => {
+    //     return innerActionTopicModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")
+    //   };
+
+      return (
+        <>
+            {innerActionTopicModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar")};
+            {innerActionTopicModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")};
+        </>
+      )
+}

--- a/src/components/UI/Tables/Modals/topicModals.js
+++ b/src/components/UI/Tables/Modals/topicModals.js
@@ -39,12 +39,12 @@ export const TopicModals = ({
       handleCloseAddModal,
       handleCloseEditModal
     } = useOpenCloseStateModalLogic({
-        openEditModal,
-        item,
-        setOpenAddModal,
-        setOpenEditModal,
-        setOriginalEditedItemId,
-        setParentItem
+        openEditModal: openEditModal,
+        item: item,
+        setOpenAddModal: setOpenAddModal,
+        setOpenEditModal: setOpenEditModal,
+        setOriginalEditedItemId: setOriginalEditedItemId,
+        setParentItem: setParentItem
     });
 
     /////// Modals de Estudiante ///////   

--- a/src/components/UI/Tables/Modals/topicModals.js
+++ b/src/components/UI/Tables/Modals/topicModals.js
@@ -12,6 +12,7 @@ import {
   InputLabel
 } from "@mui/material";
 import { NumericFormat } from "react-number-format";
+import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
 
 export const TopicModals = ({
   openAddModal, // bools para ver si se debe abrir cada modal
@@ -29,40 +30,22 @@ export const TopicModals = ({
 
 }) => {
 
-    const [newItem, setNewItem] = useState({});
-    const [editedItem, setEditedItem] = useState({}); // data
-
-    // Esto hace de handle open edit (para add no es nec xq solo se setea un bool)
-    useEffect(() => {
-      if (!openEditModal) return;
-
-      setEditedItem(item); // éste es el set complicado xq se crea acá adentro
-      setOriginalEditedItemId(item.id);        
-
-    }, [openEditModal, item]);
-    ///// Estos handles podrían ir en otro lado /////
-    const handleClickOpenAddModal = () => {
-        setOpenAddModal(true);
-    };
-    
-    const handleClickOpenEditModal = (item) => {
-        // El id puede cambiar, así que guardamos el id original
-        setOriginalEditedItemId(item.id);
-        setEditedItem(item);
-        setOpenEditModal(true);    
-    };
-
-    const handleCloseAddModal = () => {
-        setNewItem({})
-        setOpenAddModal(false);
-        setParentItem(false);
-    };
-    
-    const handleCloseEditModal = () => {
-        setEditedItem({})
-        setOpenEditModal(false);
-        setParentItem(false);
-    };
+    // Creo los estados, gestiono handle open, y obtengo los handle close.
+    const {
+      newItem,
+      setNewItem,
+      editedItem,
+      setEditedItem,
+      handleCloseAddModal,
+      handleCloseEditModal
+    } = useOpenCloseStateModalLogic({
+        openEditModal,
+        item,
+        setOpenAddModal,
+        setOpenEditModal,
+        setOriginalEditedItemId,
+        setParentItem
+    });
 
     /////// Modals de Estudiante ///////   
     const innerActionTopicModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, titleText, confirmButtonText) => {
@@ -161,18 +144,18 @@ export const TopicModals = ({
         )
       };
 
-    //   const addTopicModal = () => {
-    //     return innerActionTopicModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar");
-    //   };
+      const addTopicModal = () => {
+        return innerActionTopicModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar");
+      };
     
-    //   const editTopicModal = () => {
-    //     return innerActionTopicModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")
-    //   };
+      const editTopicModal = () => {
+        return innerActionTopicModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")
+      };
 
       return (
         <>
-            {innerActionTopicModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar")};
-            {innerActionTopicModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")};
+            {addTopicModal()};
+            {editTopicModal()};
         </>
       )
 }

--- a/src/components/UI/Tables/Modals/topicModals.js
+++ b/src/components/UI/Tables/Modals/topicModals.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {
   Button,
   TextField,
@@ -62,84 +62,91 @@ export const TopicModals = ({
             >
               {titleText} Tema
             </DialogTitle>
-            <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
-              <TextField
-                variant="outlined"
-                fullWidth
-                margin="normal"
-                label="Titulo"
-                value={item["name"] || ""}
-                required
-                onChange={(e) => setItem({ ...item, name: e.target.value })}
-              />
-              <InputLabel>Seleccionar categoria</InputLabel>
-              <Select
-                value={
-                  item["category"] || ""
-                }
-                label="Categorías"
-                onChange={(e) =>
-                  setItem({ ...item, category: e.target.value })
-                }
-                margin="normal"
-    
-                sx={{ marginBottom: "8px" }}
-                required
-                fullWidth
-              >
-                <MenuItem key="" value="" disabled>
-                  Seleccionar categoria
-                </MenuItem>
-                {categories.map((category) => (
-                  <MenuItem key={category} value={category}>
-                    {category}
+            <form
+              onSubmit={(e) => {
+                e.preventDefault(); // previene el reload del form
+                handleConfirmAction(item, setItem, handleCloseModal);
+              }}
+            >
+              <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
+                <TextField
+                  variant="outlined"
+                  fullWidth
+                  margin="normal"
+                  label="Titulo"
+                  value={item["name"] || ""}
+                  required
+                  onChange={(e) => setItem({ ...item, name: e.target.value })}
+                />
+                <InputLabel>Seleccionar categoria</InputLabel>
+                <Select
+                  value={
+                    item["category"] || ""
+                  }
+                  label="Categorías"
+                  onChange={(e) =>
+                    setItem({ ...item, category: e.target.value })
+                  }
+                  margin="normal"
+      
+                  sx={{ marginBottom: "8px" }}
+                  required
+                  fullWidth
+                >
+                  <MenuItem key="" value="" disabled>
+                    Seleccionar categoria
                   </MenuItem>
-                ))}
-              </Select>
-              <InputLabel margin="normal">Seleccionar tutor</InputLabel>
-              <Select
-                margin="normal"
-                value={
-                  item["tutor_email"] || ""
-                }
-                label="Email del tutor"
-                onChange={(e) =>
-                  setItem({ ...item, tutor_email: e.target.value })
-                }
-                required
-                fullWidth
-              >
-                <MenuItem key="" value="" disabled>
-                  Seleccionar tutor
-                </MenuItem>
-                {tutors.map((tutor) => (
-                  <MenuItem key={tutor.id} value={tutor.email}>
-                    {tutor.email}
+                  {categories.map((category) => (
+                    <MenuItem key={category} value={category}>
+                      {category}
+                    </MenuItem>
+                  ))}
+                </Select>
+                <InputLabel margin="normal">Seleccionar tutor</InputLabel>
+                <Select
+                  margin="normal"
+                  value={
+                    item["tutor_email"] || ""
+                  }
+                  label="Email del tutor"
+                  onChange={(e) =>
+                    setItem({ ...item, tutor_email: e.target.value })
+                  }
+                  required
+                  fullWidth
+                >
+                  <MenuItem key="" value="" disabled>
+                    Seleccionar tutor
                   </MenuItem>
-                ))}
-              </Select>
-              <NumericFormat
-                fullWidth
-                allowNegative={false}
-                customInput={TextField}
-                variant="outlined"
-                margin="normal"
-                label="Capacidad"
-                value={item["capacity"] || ""}
-                required
-                onChange={(e) =>
-                  setItem({ ...item, capacity: parseInt(e.target.value) })
-                }
-              />
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={handleCloseModal} variant="outlined" color="error">
-                Cancelar
-              </Button>
-              <Button onClick={() => handleConfirmAction(item, setItem, handleCloseModal)} variant="contained" color="primary">
-                {confirmButtonText}
-              </Button>
-            </DialogActions>
+                  {tutors.map((tutor) => (
+                    <MenuItem key={tutor.id} value={tutor.email}>
+                      {tutor.email}
+                    </MenuItem>
+                  ))}
+                </Select>
+                <NumericFormat
+                  fullWidth
+                  allowNegative={false}
+                  customInput={TextField}
+                  variant="outlined"
+                  margin="normal"
+                  label="Capacidad"
+                  value={item["capacity"] || ""}
+                  required
+                  onChange={(e) =>
+                    setItem({ ...item, capacity: parseInt(e.target.value) })
+                  }
+                />
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={handleCloseModal} variant="outlined" color="error">
+                  Cancelar
+                </Button>
+                <Button type="submit" variant="contained" color="primary">
+                  {confirmButtonText}
+                </Button>
+              </DialogActions>
+            </form>
           </Dialog>
         )
       };

--- a/src/components/UI/Tables/Modals/topicModals.js
+++ b/src/components/UI/Tables/Modals/topicModals.js
@@ -72,6 +72,7 @@ export const TopicModals = ({
               <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
                 <TextField
                   variant="outlined"
+                  autoFocus
                   fullWidth
                   margin="normal"
                   label="Titulo"

--- a/src/components/UI/Tables/Modals/tutorModals.js
+++ b/src/components/UI/Tables/Modals/tutorModals.js
@@ -42,7 +42,7 @@ export const TutorModals = ({
       });
 
       /////// Modals de Estudiante ///////      
-      const innerActionTutorModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {
+      const innerActionTutorModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
             <DialogTitle
@@ -76,6 +76,7 @@ export const TutorModals = ({
                   onChange={(e) =>
                     setItem({ ...item, id: parseInt(e.target.value) })
                   }
+                  disabled={disableEditId}
                 />
                 <TextField
                   variant="outlined"
@@ -141,7 +142,7 @@ export const TutorModals = ({
       };
     
       const editTutorModal = () => {
-        return innerActionTutorModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")
+        return innerActionTutorModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
       };
 
       return (

--- a/src/components/UI/Tables/Modals/tutorModals.js
+++ b/src/components/UI/Tables/Modals/tutorModals.js
@@ -8,6 +8,7 @@ import {
   DialogActions,
 } from "@mui/material";
 import { NumericFormat } from "react-number-format";
+import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
 
 export const TutorModals = ({
   openAddModal, // bools para ver si se debe abrir cada modal
@@ -22,40 +23,22 @@ export const TutorModals = ({
   setParentItem
 }) => {
 
-      const [newItem, setNewItem] = useState({});
-      const [editedItem, setEditedItem] = useState({}); // data
-
-      // Esto hace de handle open edit (para add no es nec xq solo se setea un bool)
-      useEffect(() => {
-        if (!openEditModal) return;
-
-        setEditedItem(item); // éste es el set complicado xq se crea acá adentro
-        setOriginalEditedItemId(item.id);        
-
-      }, [openEditModal, item]);
-      ///// Estos handles podrían ir en otro lado /////
-      const handleClickOpenAddModal = () => {
-          setOpenAddModal(true);
-      };
-      
-      const handleClickOpenEditModal = (item) => {
-          // El id puede cambiar, así que guardamos el id original
-          setOriginalEditedItemId(item.id);
-          setEditedItem(item);
-          setOpenEditModal(true);    
-      };
-
-      const handleCloseAddModal = () => {
-          setNewItem({})
-          setOpenAddModal(false);
-          setParentItem(false);
-      };
-      
-      const handleCloseEditModal = () => {
-          setEditedItem({})
-          setOpenEditModal(false);
-          setParentItem(false);
-      };
+      // Creo los estados, gestiono handle open, y obtengo los handle close.
+      const {
+        newItem,
+        setNewItem,
+        editedItem,
+        setEditedItem,
+        handleCloseAddModal,
+        handleCloseEditModal
+      } = useOpenCloseStateModalLogic({
+          openEditModal,
+          item,
+          setOpenAddModal,
+          setOpenEditModal,
+          setOriginalEditedItemId,
+          setParentItem
+      });
 
       /////// Modals de Estudiante ///////      
       const innerActionTutorModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {
@@ -145,18 +128,18 @@ export const TutorModals = ({
         )
       };
 
-    //   const addTutorModal = () => {
-    //     return innerActionTutorModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar")
-    //   };
+      const addTutorModal = () => {
+        return innerActionTutorModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar")
+      };
     
-    //   const editTutorModal = () => {
-    //     return innerActionTutorModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")
-    //   };
+      const editTutorModal = () => {
+        return innerActionTutorModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")
+      };
 
       return (
         <>
-            {innerActionTutorModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar")};
-            {innerActionTutorModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")};
+            {addTutorModal()};
+            {editTutorModal()};
         </>
       )
 }

--- a/src/components/UI/Tables/Modals/tutorModals.js
+++ b/src/components/UI/Tables/Modals/tutorModals.js
@@ -32,12 +32,12 @@ export const TutorModals = ({
         handleCloseAddModal,
         handleCloseEditModal
       } = useOpenCloseStateModalLogic({
-          openEditModal,
-          item,
-          setOpenAddModal,
-          setOpenEditModal,
-          setOriginalEditedItemId,
-          setParentItem
+          openEditModal: openEditModal,
+          item: item,
+          setOpenAddModal: setOpenAddModal,
+          setOpenEditModal: setOpenEditModal,
+          setOriginalEditedItemId: setOriginalEditedItemId,
+          setParentItem: setParentItem
       });
 
       /////// Modals de Estudiante ///////      

--- a/src/components/UI/Tables/Modals/tutorModals.js
+++ b/src/components/UI/Tables/Modals/tutorModals.js
@@ -10,6 +10,7 @@ import {
 import { NumericFormat } from "react-number-format";
 import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
 
+/* Modals para Agregar y Editar un/a tutor/a */
 export const TutorModals = ({
   openAddModal, // bools para ver si se debe abrir cada modal
   openEditModal,
@@ -17,7 +18,7 @@ export const TutorModals = ({
   setOpenEditModal,
   handleAddItem, // las acciones al clickear confirmar desde cada modal
   handleEditItem,
-  originalEditedItemId, // para pasárselo a la función que habla con la api al confirmar _ no, ya lo tiene si se crea afuera. Necesito su set si debo tener acá ese handle.
+  originalEditedItemId, // para pasárselo a la función que habla con la api al confirmar, y su set para el handle
   setOriginalEditedItemId,
   item, // recibido del parent, y su set para flushearlo al salir
   setParentItem

--- a/src/components/UI/Tables/Modals/tutorModals.js
+++ b/src/components/UI/Tables/Modals/tutorModals.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {
   Button,
   TextField,
@@ -55,75 +55,82 @@ export const TutorModals = ({
             >
               {TitleText} Tutor
             </DialogTitle>
-            <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
-              <NumericFormat
-                fullWidth
-                allowNegative={false}
-                customInput={TextField}
-                variant="outlined"
-                autoFocus
-                margin="normal"
-                label="DNI o Identificación"
-                value={item["id"] || ""}
-                required
-                onChange={(e) =>
-                  setItem({ ...item, id: parseInt(e.target.value) })
-                }
-              />
-              <TextField
-                variant="outlined"
-                fullWidth
-                margin="normal"
-                label="Nombre"
-                value={item["name"] || ""}
-                required
-                onChange={(e) => setItem({ ...item, name: e.target.value })}
-              />
-              <TextField
-                variant="outlined"
-                fullWidth
-                margin="normal"
-                label="Apellido"
-                value={item["last_name"] || ""}
-                required
-                onChange={(e) =>
-                  setItem({ ...item, last_name: e.target.value })
-                }
-              />
-              <TextField
-                label="Email"
-                type="email"
-                fullWidth
-                margin="normal"
-                variant="outlined"
-                value={item["email"] || ""}
-                onChange={(e) =>
-                  setItem({ ...item, email: e.target.value })
-                }
-                required
-              />
-              <NumericFormat
-                fullWidth
-                allowNegative={false}
-                customInput={TextField}
-                variant="outlined"
-                margin="normal"
-                label="Capacidad"
-                value={item["capacity"] || ""}
-                required
-                onChange={(e) =>
-                  setItem({ ...item, capacity: parseInt(e.target.value) })
-                }
-              />
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={handleCloseModal} variant="outlined" color="error">
-                Cancelar
-              </Button>
-              <Button onClick={() => handleConfirmAction(item, setItem, handleCloseModal)} variant="contained" color="primary">
-                {ConfirmButtonText}
-              </Button>
-            </DialogActions>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault(); // previene el reload del form
+                handleConfirmAction(item, setItem, handleCloseModal);
+              }}
+            >
+              <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
+                <NumericFormat
+                  fullWidth
+                  allowNegative={false}
+                  customInput={TextField}
+                  variant="outlined"
+                  autoFocus
+                  margin="normal"
+                  label="DNI o Identificación"
+                  value={item["id"] || ""}
+                  required
+                  onChange={(e) =>
+                    setItem({ ...item, id: parseInt(e.target.value) })
+                  }
+                />
+                <TextField
+                  variant="outlined"
+                  fullWidth
+                  margin="normal"
+                  label="Nombre"
+                  value={item["name"] || ""}
+                  required
+                  onChange={(e) => setItem({ ...item, name: e.target.value })}
+                />
+                <TextField
+                  variant="outlined"
+                  fullWidth
+                  margin="normal"
+                  label="Apellido"
+                  value={item["last_name"] || ""}
+                  required
+                  onChange={(e) =>
+                    setItem({ ...item, last_name: e.target.value })
+                  }
+                />
+                <TextField
+                  label="Email"
+                  type="email"
+                  fullWidth
+                  margin="normal"
+                  variant="outlined"
+                  value={item["email"] || ""}
+                  onChange={(e) =>
+                    setItem({ ...item, email: e.target.value })
+                  }
+                  required
+                />
+                <NumericFormat
+                  fullWidth
+                  allowNegative={false}
+                  customInput={TextField}
+                  variant="outlined"
+                  margin="normal"
+                  label="Capacidad"
+                  value={item["capacity"] || ""}
+                  required
+                  onChange={(e) =>
+                    setItem({ ...item, capacity: parseInt(e.target.value) })
+                  }
+                />
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={handleCloseModal} variant="outlined" color="error">
+                  Cancelar
+                </Button>
+                <Button type="submit" variant="contained" color="primary">
+                  {ConfirmButtonText}
+                </Button>
+              </DialogActions>
+           </form>
           </Dialog>
         )
       };

--- a/src/components/UI/Tables/Modals/tutorModals.js
+++ b/src/components/UI/Tables/Modals/tutorModals.js
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 import { NumericFormat } from "react-number-format";
 
-export const StudentModals = ({
+export const TutorModals = ({
   openAddModal, // bools para ver si se debe abrir cada modal
   openEditModal,
   setOpenAddModal, // necesarias para cerrar los modals
@@ -20,12 +20,11 @@ export const StudentModals = ({
   setOriginalEditedItemId,
   item, // recibido del parent, y su set para flushearlo al salir
   setParentItem
-  
 }) => {
-  
+
       const [newItem, setNewItem] = useState({});
       const [editedItem, setEditedItem] = useState({}); // data
-      
+
       // Esto hace de handle open edit (para add no es nec xq solo se setea un bool)
       useEffect(() => {
         if (!openEditModal) return;
@@ -58,8 +57,8 @@ export const StudentModals = ({
           setParentItem(false);
       };
 
-      /////// Modals de Estudiante ///////
-      const innerActionStudentModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {    
+      /////// Modals de Estudiante ///////      
+      const innerActionTutorModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
             <DialogTitle
@@ -71,7 +70,7 @@ export const StudentModals = ({
                 padding: "16px 24px",
               }}
             >
-              {TitleText} Alumno
+              {TitleText} Tutor
             </DialogTitle>
             <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
               <NumericFormat
@@ -81,7 +80,7 @@ export const StudentModals = ({
                 variant="outlined"
                 autoFocus
                 margin="normal"
-                label="Padrón"
+                label="DNI o Identificación"
                 value={item["id"] || ""}
                 required
                 onChange={(e) =>
@@ -120,6 +119,19 @@ export const StudentModals = ({
                 }
                 required
               />
+              <NumericFormat
+                fullWidth
+                allowNegative={false}
+                customInput={TextField}
+                variant="outlined"
+                margin="normal"
+                label="Capacidad"
+                value={item["capacity"] || ""}
+                required
+                onChange={(e) =>
+                  setItem({ ...item, capacity: parseInt(e.target.value) })
+                }
+              />
             </DialogContent>
             <DialogActions>
               <Button onClick={handleCloseModal} variant="outlined" color="error">
@@ -133,17 +145,18 @@ export const StudentModals = ({
         )
       };
 
-      // const addStudentModal = () => {
-      //   return innerActionStudentModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Agregar")
-      // }
+    //   const addTutorModal = () => {
+    //     return innerActionTutorModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar")
+    //   };
     
-      // const editStudentModal = () => {
-      //   return innerActionStudentModal(openEditModal, handleCloseEditModal, handleEdit, editedItem, setEditedItem, "Editar", "Guardar")
-      // }
-  return (
-    <>
-      {innerActionStudentModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Agregar")};
-      {innerActionStudentModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")};
-    </>
-  )
+    //   const editTutorModal = () => {
+    //     return innerActionTutorModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")
+    //   };
+
+      return (
+        <>
+            {innerActionTutorModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar")};
+            {innerActionTutorModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")};
+        </>
+      )
 }

--- a/src/components/UI/Tables/Modals/useOpenCloseStateModalLogic.js
+++ b/src/components/UI/Tables/Modals/useOpenCloseStateModalLogic.js
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 
-// Cada vez que se llama a este custom hook, se llama de nuevo a useState, por lo que cada llamada a este custom hook
-// tiene su propio estado (no compartido entre llamadas a este hook).
+/* Comportamiento común a todos los modals de agregar y editar estudiante/tutor/tema. Dichos modals usan esto.
+ * Aclaración: cada llamada a este custom hook tiene su propio estado (se llama nuevamente a useState cada vez,
+ * es decir que no se comparte entre llamadas a este hook).*/
 export const useOpenCloseStateModalLogic = ({openEditModal, item, setOpenAddModal, setOpenEditModal, setOriginalEditedItemId, setParentItem}) => {
       
       const [newItem, setNewItem] = useState({});
@@ -11,22 +12,16 @@ export const useOpenCloseStateModalLogic = ({openEditModal, item, setOpenAddModa
       useEffect(() => {
         if (!openEditModal) return;
 
-        setEditedItem(item); // éste es el set complicado xq se crea acá adentro
+        setEditedItem(item);
+        // El id puede cambiar, así que guardamos el id original
         setOriginalEditedItemId(item.id);        
 
       }, [openEditModal, item]);
       
       ///// Estos handles son comunes a todos los modals /////
-      const handleClickOpenAddModal = () => {
-          setOpenAddModal(true);
-      };
-      
-      const handleClickOpenEditModal = (item) => {
-          // El id puede cambiar, así que guardamos el id original
-          setOriginalEditedItemId(item.id);
-          setEditedItem(item);
-          setOpenEditModal(true);    
-      };
+      // Para abrir solamente se setea un bool desde afuera y el useEffect de acá arriba captura eso para el caso Editar
+      // (caso Agregar no hay más cosas por hacer al abrir); para cerrar se usan estos handle close en los modal,
+      // y también se pasan a la función que se ejecuta luego de confirmar el modal para que lo cierre ante error.
 
       const handleCloseAddModal = () => {
           setNewItem({})

--- a/src/components/UI/Tables/Modals/useOpenCloseStateModalLogic.js
+++ b/src/components/UI/Tables/Modals/useOpenCloseStateModalLogic.js
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+
+// Cada vez que se llama a este custom hook, se llama de nuevo a useState, por lo que cada llamada a este custom hook
+// tiene su propio estado (no compartido entre llamadas a este hook).
+export const useOpenCloseStateModalLogic = ({openEditModal, item, setOpenAddModal, setOpenEditModal, setOriginalEditedItemId, setParentItem}) => {
+      
+      const [newItem, setNewItem] = useState({});
+      const [editedItem, setEditedItem] = useState({}); // data
+      
+      // Esto hace de handle open edit (el handle open add no es necesario xq solo se setea un bool desde afuera)
+      useEffect(() => {
+        if (!openEditModal) return;
+
+        setEditedItem(item); // éste es el set complicado xq se crea acá adentro
+        setOriginalEditedItemId(item.id);        
+
+      }, [openEditModal, item]);
+      
+      ///// Estos handles son comunes a todos los modals /////
+      const handleClickOpenAddModal = () => {
+          setOpenAddModal(true);
+      };
+      
+      const handleClickOpenEditModal = (item) => {
+          // El id puede cambiar, así que guardamos el id original
+          setOriginalEditedItemId(item.id);
+          setEditedItem(item);
+          setOpenEditModal(true);    
+      };
+
+      const handleCloseAddModal = () => {
+          setNewItem({})
+          setOpenAddModal(false);
+          setParentItem(false);
+      };
+      
+      const handleCloseEditModal = () => {
+          setEditedItem({})
+          setOpenEditModal(false);
+          setParentItem(false);
+      };
+
+      return {newItem, setNewItem, editedItem, setEditedItem, handleCloseAddModal, handleCloseEditModal};
+};

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -157,7 +157,7 @@ const ParentTable = ({
         setNewItem({});
         setNotification({
           open: true,
-          message: `Alumno agregado éxitosamente`,
+          message: `Alumno agregado exitosamente`,
           status: "success",
         });
         setData([...items, item]);
@@ -167,7 +167,7 @@ const ParentTable = ({
         setNewItem({});
         setNotification({
           open: true,
-          message: `Tutor agregado éxitosamente`,
+          message: `Tutor agregado exitosamente`,
           status: "success",
         });
         setData([...items, item]);
@@ -177,7 +177,7 @@ const ParentTable = ({
         setNewItem({});
         setNotification({
           open: true,
-          message: `Tema agregado éxitosamente`,
+          message: `Tema agregado exitosamente`,
           status: "success",
         });
         setData([...items, item]);

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -32,6 +32,7 @@ import { TableType, TableTypeSingularLabel } from "./TableType";
 import { StudentModals } from "./Modals/studentModals";
 import { TutorModals } from "./Modals/tutorModals";
 import { TopicModals } from "./Modals/topicModals";
+import { addCapacityToTutors } from "../../../utils/addCapacityToTutors";
 
 const Root = styled(Paper)(({ theme }) => ({
   marginTop: theme.spacing(4),
@@ -74,25 +75,17 @@ const ParentTable = ({
 
   const period = useSelector((state) => state.period);
   const user = useSelector((state) => state.user);
-  const tutors = Object.values(useSelector((state) => state.tutors))
+  const tutorsWithoutCapacityField = Object.values(useSelector((state) => state.tutors))
   .map(({ version, rehydrated, ...rest }) => rest) // Filtra las propiedades 'version' y 'rehydrated'
-  .filter((item) => Object.keys(item).length > 0) // Elimina objetos vacíos
-  .map((item) => { // Agrega capacity a cada tutor
-    const selectedTutorPeriod = item.tutor_periods.find(tp => tp.period_id === period.id);
-    const capacity = selectedTutorPeriod ? selectedTutorPeriod.capacity : null;
-    return {...item, capacity};
-  });
+  .filter((item) => Object.keys(item).length > 0); // Elimina objetos vacíos
+  const tutors = addCapacityToTutors(tutorsWithoutCapacityField, period);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         const responseData = await getTableData(endpoint, user);
         if (title === TableType.TUTORS){
-          const tutorsWithCapacityField = responseData.map((item) => { // Agrega capacity a cada tutor
-            const selectedTutorPeriod = item.tutor_periods.find(tp => tp.period_id === period.id);
-            const capacity = selectedTutorPeriod ? selectedTutorPeriod.capacity : null;
-            return {...item, capacity};
-          });
+          const tutorsWithCapacityField = addCapacityToTutors(responseData, period);
           setData(tutorsWithCapacityField);
         } else {
           setData(responseData);
@@ -116,20 +109,12 @@ const ParentTable = ({
         if (!data) {
           // Seteo inicial xq hasta ahora data no vale nada
           // Así que agrego capacity a 'items'
-          const tutorsWithCapacityField = items.map((item) => { // Agrega capacity a cada tutor
-            const selectedTutorPeriod = item.tutor_periods.find(tp => tp.period_id === period.id);
-            const capacity = selectedTutorPeriod ? selectedTutorPeriod.capacity : null;
-            return {...item, capacity};
-          });
+          const tutorsWithCapacityField = addCapacityToTutors(items, period);
           setData(tutorsWithCapacityField);
           
         } else {
           // Agrego capacity a lo que ya tenía 'data'
-          const tutorsWithCapacityField = data.map((item) => { // Agrega capacity a cada tutor
-            const selectedTutorPeriod = item.tutor_periods.find(tp => tp.period_id === period.id);
-            const capacity = selectedTutorPeriod ? selectedTutorPeriod.capacity : null;
-            return {...item, capacity};
-          });
+          const tutorsWithCapacityField = addCapacityToTutors(data, period);
           setData(tutorsWithCapacityField);
         }
       }

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -510,8 +510,11 @@ const ParentTable = ({
   };
 
   const addTopicModal = () => {
+    return innerActionTopicModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar");
+  }
+  const innerActionTopicModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, titleText, confirmButtonText) => {
     return (
-      <Dialog open={openAddModal} onClose={handleCloseAddModal} maxWidth="sm" fullWidth>
+      <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
         <DialogTitle
           sx={{
             fontWeight: "bold",
@@ -521,7 +524,7 @@ const ParentTable = ({
             padding: "16px 24px",
           }}
         >
-          Agregar Nuevo Tema
+          {titleText} Tema
         </DialogTitle>
         <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
           <TextField
@@ -529,18 +532,18 @@ const ParentTable = ({
             fullWidth
             margin="normal"
             label="Titulo"
-            value={newItem["name"] || ""}
+            value={item["name"] || ""}
             required
-            onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
+            onChange={(e) => setItem({ ...item, name: e.target.value })}
           />
           <InputLabel>Seleccionar categoria</InputLabel>
           <Select
             value={
-              newItem["category"] || ""
+              item["category"] || ""
             }
             label="Categorías"
             onChange={(e) =>
-              setNewItem({ ...newItem, category: e.target.value })
+              setItem({ ...item, category: e.target.value })
             }
             margin="normal"
 
@@ -561,11 +564,11 @@ const ParentTable = ({
           <Select
             margin="normal"
             value={
-              newItem["tutor_email"] || ""
+              item["tutor_email"] || ""
             }
             label="Email del tutor"
             onChange={(e) =>
-              setNewItem({ ...newItem, tutor_email: e.target.value })
+              setItem({ ...item, tutor_email: e.target.value })
             }
             required
             fullWidth
@@ -586,19 +589,19 @@ const ParentTable = ({
             variant="outlined"
             margin="normal"
             label="Capacidad"
-            value={newItem["capacity"] || ""}
+            value={item["capacity"] || ""}
             required
             onChange={(e) =>
-              setNewItem({ ...newItem, capacity: parseInt(e.target.value) })
+              setItem({ ...item, capacity: parseInt(e.target.value) })
             }
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleCloseAddModal} variant="outlined" color="error">
+          <Button onClick={handleCloseModal} variant="outlined" color="error">
             Cancelar
           </Button>
-          <Button onClick={handleAddItem} variant="contained" color="primary">
-            Agregar
+          <Button onClick={handleConfirmAction} variant="contained" color="primary">
+            {confirmButtonText}
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -247,6 +247,80 @@ const ParentTable = ({
       return String(itemValue).toLowerCase().includes(searchTerm.toLowerCase());
     });
   });
+  
+  const addStudentModal = () => {
+    return (
+      <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+        <DialogTitle
+          sx={{
+            fontWeight: "bold",
+            textAlign: "center",
+            backgroundColor: "#f5f5f5",
+            color: "#333",
+            padding: "16px 24px",
+          }}
+        >
+          Agregar Nuevo Alumno
+        </DialogTitle>
+        <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
+          <NumericFormat
+            fullWidth
+            allowNegative={false}
+            customInput={TextField}
+            variant="outlined"
+            autoFocus
+            margin="normal"
+            label="Padrón"
+            value={newItem["id"] || ""}
+            required
+            onChange={(e) =>
+              setNewItem({ ...newItem, id: parseInt(e.target.value) })
+            }
+          />
+          <TextField
+            variant="outlined"
+            fullWidth
+            margin="normal"
+            label="Nombre"
+            value={newItem["name"] || ""}
+            required
+            onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
+          />
+          <TextField
+            variant="outlined"
+            fullWidth
+            margin="normal"
+            label="Apellido"
+            value={newItem["last_name"] || ""}
+            required
+            onChange={(e) =>
+              setNewItem({ ...newItem, last_name: e.target.value })
+            }
+          />
+          <TextField
+            label="Email"
+            type="email"
+            fullWidth
+            margin="normal"
+            variant="outlined"
+            value={newItem["email"] || ""}
+            onChange={(e) =>
+              setNewItem({ ...newItem, email: e.target.value })
+            }
+            required
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} variant="outlined" color="error">
+            Cancelar
+          </Button>
+          <Button onClick={handleAddItem} variant="contained" color="primary">
+            Agregar
+          </Button>
+        </DialogActions>
+      </Dialog>
+    )
+  }
 
   if (loading) return <Typography variant="h6">Cargando...</Typography>;
   const categories = title === "Temas" ? getCategories(items) : [];
@@ -316,77 +390,7 @@ const ParentTable = ({
           </TableContainer>
         </Root>
       </Container>
-      {title === "Alumnos" && (
-        <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-          <DialogTitle
-            sx={{
-              fontWeight: "bold",
-              textAlign: "center",
-              backgroundColor: "#f5f5f5",
-              color: "#333",
-              padding: "16px 24px",
-            }}
-          >
-            Agregar Nuevo Alumno
-          </DialogTitle>
-          <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
-            <NumericFormat
-              fullWidth
-              allowNegative={false}
-              customInput={TextField}
-              variant="outlined"
-              autoFocus
-              margin="normal"
-              label="Padrón"
-              value={newItem["id"] || ""}
-              required
-              onChange={(e) =>
-                setNewItem({ ...newItem, id: parseInt(e.target.value) })
-              }
-            />
-            <TextField
-              variant="outlined"
-              fullWidth
-              margin="normal"
-              label="Nombre"
-              value={newItem["name"] || ""}
-              required
-              onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
-            />
-            <TextField
-              variant="outlined"
-              fullWidth
-              margin="normal"
-              label="Apellido"
-              value={newItem["last_name"] || ""}
-              required
-              onChange={(e) =>
-                setNewItem({ ...newItem, last_name: e.target.value })
-              }
-            />
-            <TextField
-              label="Email"
-              type="email"
-              fullWidth
-              margin="normal"
-              variant="outlined"
-              value={newItem["email"] || ""}
-              onChange={(e) =>
-                setNewItem({ ...newItem, email: e.target.value })
-              }
-              required
-            />
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={handleClose} variant="outlined" color="error">
-              Cancelar
-            </Button>
-            <Button onClick={handleAddItem} variant="contained" color="primary">
-              Agregar
-            </Button>
-          </DialogActions>
-        </Dialog>
-      )}
+      {title === "Alumnos" && addStudentModal()}
 
       {title === "Tutores" && (
         <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -28,7 +28,7 @@ import { setTutors } from "../../../redux/slices/tutorsSlice";
 import { getCategories } from "../../../utils/getCategories";
 import { addTopic, editTopic } from "../../../api/handleTopics";
 import { setTopics } from "../../../redux/slices/topicsSlice";
-import { TableType } from "./TableType";
+import { TableType, TableTypeSingularLabel } from "./TableType";
 import { StudentModals } from "./Modals/studentModals";
 import { TutorModals } from "./Modals/tutorModals";
 import { TopicModals } from "./Modals/topicModals";
@@ -161,12 +161,12 @@ const ParentTable = ({
   
   const dispatch = useDispatch();
 
-  const addItemToGenericTable = async (apiAddFunction, newItem, setNewItem, stringItemType, setReducer) => {
+  const addItemToGenericTable = async (apiAddFunction, newItem, setNewItem, setReducer) => {
     const item = await apiAddFunction(newItem, user, period.id); // el add
     setNewItem({});
     setNotification({
       open: true,
-      message: `Se agregó ${stringItemType} exitosamente`, // 'alumno'
+      message: `Se agregó ${TableTypeSingularLabel[title]||''} exitosamente`, // 'alumno'
       status: "success",
     });
     setData((prevData) => [...prevData, item]);
@@ -176,17 +176,17 @@ const ParentTable = ({
   const handleAddItem = async (newItem, setNewItem, handleCloseAddModal) => {
     try {
       if (title === TableType.STUDENTS) {
-        await addItemToGenericTable(addStudent, newItem, setNewItem, "alumno", setStudents);
+        await addItemToGenericTable(addStudent, newItem, setNewItem, setStudents);
       } else if (title === TableType.TUTORS) {
-        await addItemToGenericTable(addTutor, newItem, setNewItem, "tutor/a", setTutors);
+        await addItemToGenericTable(addTutor, newItem, setNewItem, setTutors);
       } else if (title === TableType.TOPICS) {
-        await addItemToGenericTable(addTopic, newItem, setNewItem, "tema", setTopics);
+        await addItemToGenericTable(addTopic, newItem, setNewItem, setTopics);
       }
     } catch (err) {
       console.error(`Error when adding new ${title}:`, err);
       setNotification({
         open: true,
-        message: `Error al agregar ${title.toLowerCase()}. Por favor, vuelva a intentar más tarde.`,
+        message: `Error al agregar ${TableTypeSingularLabel[title]||''}.`,
         status: "error",
       });
     } finally {
@@ -194,13 +194,13 @@ const ParentTable = ({
     }
   };
 
-  const editItemInGenericTable = async (apiEditFunction, editedItem, setEditedItem, stringItemType, setReducer) => {
+  const editItemInGenericTable = async (apiEditFunction, editedItem, setEditedItem, setReducer) => {
     const item = await apiEditFunction(originalEditedItemId, period.id, editedItem, user);
     setEditedItem({});
     setOriginalEditedItemId(null);
     setNotification({
       open: true,
-      message: `Se editó ${stringItemType} exitosamente`,
+      message: `Se editó ${TableTypeSingularLabel[title]||''} exitosamente`,
       status: "success",
     });
     setData((prevData) =>
@@ -215,17 +215,17 @@ const ParentTable = ({
     try {
       console.log("TUTOR item desde su PARENT:", editedItem);
       if (title === TableType.STUDENTS) {
-        await editItemInGenericTable(editStudent, editedItem, setEditedItem, "alumno", setStudents);
+        await editItemInGenericTable(editStudent, editedItem, setEditedItem, setStudents);
       } else if (title === TableType.TUTORS) {
-        await editItemInGenericTable(editTutor, editedItem, setEditedItem, "tutor/a", setTutors);       
+        await editItemInGenericTable(editTutor, editedItem, setEditedItem, setTutors);       
       } else if (title === TableType.TOPICS) {
-        await editItemInGenericTable(editTopic, editedItem, setEditedItem, "tema", setTopics);
+        await editItemInGenericTable(editTopic, editedItem, setEditedItem, setTopics);
       }
     } catch (err) {
       console.error(`Error when editing new ${title}:`, err);
       setNotification({
         open: true,
-        message: `Error al editar ${title.toLowerCase()}. Por favor, vuelva a intentar más tarde.`,
+        message: `Error al editar ${TableTypeSingularLabel[title]||''}.`,
         status: "error",
       });
     } finally {
@@ -374,7 +374,7 @@ const ParentTable = ({
                       <Stack direction="row" spacing={1}>
                         <Button
                             onClick={() => {setOpenEditModal(true); console.log("PASANDO ITEM:", item); setItemToPassToModal(item)}}
-                            style={{ backgroundColor: "#e0711d", color: "white" }}
+                            style={{ backgroundColor: "#e0711d", color: "white" }} //botón naranja
                             >
                             Editar
                           </Button>

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -34,7 +34,7 @@ import { setStudents } from "../../../redux/slices/studentsSlice";
 import { addTutor, editTutor } from "../../../api/handleTutors";
 import { setTutors } from "../../../redux/slices/tutorsSlice";
 import { getCategories } from "../../../utils/getCategories";
-import { addTopic } from "../../../api/handleTopics";
+import { addTopic, editTopic } from "../../../api/handleTopics";
 import { setTopics } from "../../../redux/slices/topicsSlice";
 import { TableType } from "./TableType";
 
@@ -228,18 +228,22 @@ const ParentTable = ({
           prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem)))
         );
       }
-      // Esto de acá abajo que está comentado es copypaste del add, lo modificaré después []
-      /* else if (title === TableType.TOPICS) {
-        const item = await addTopic(newItem, user, period.id);
-        setNewItem({});
+      else if (title === TableType.TOPICS) {
+        const item = await editTopic(originalEditedItemId, period.id, editedItem, user); //[]
+        setEditedItem({});
+        setOriginalEditedItemId(null);
         setNotification({
           open: true,
           message: `Tema editado exitosamente`,
           status: "success",
         });
-        setData([...items, item]);
-        dispatch(setTopics([...items, item]));
-      }*/
+        setData((prevData) =>
+          prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem))
+        );
+        dispatch(setStudents((prevData) =>
+          prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem)))
+        );
+      }
     } catch (err) {
       console.error(`Error when editing new ${title}:`, err);
       setNotification({

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -76,6 +76,7 @@ const ParentTable = ({
   const [openAddModal, setOpenAddModal] = useState(false);
   const [openEditModal, setOpenEditModal] = useState(false);
   const [originalEditedItemId, setOriginalEditedItemId] = useState(null);
+  const [itemToPassToModal, setItemToPassToModal] = useState(null);
 
   const user = useSelector((state) => state.user);
   const tutors = Object.values(useSelector((state) => state.tutors))
@@ -367,7 +368,7 @@ const ParentTable = ({
                       <Stack direction="row" spacing={1}>
                         <Button
                             //onClick={() => handleClickOpenEditModal(item)}
-                            onClick={() => setOpenEditModal(true)}
+                            onClick={() => {setOpenEditModal(true); setItemToPassToModal(item)}}
                             style={{ backgroundColor: "#e0711d", color: "white" }}
                             >
                             Editar
@@ -402,6 +403,8 @@ const ParentTable = ({
           handleEditItem={handleEditItem}
           originalEditedItemId={originalEditedItemId}
           setOriginalEditedItemId={setOriginalEditedItemId}
+          item={itemToPassToModal}
+          setParentItem={setItemToPassToModal}
        />
 
       }; 

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -131,11 +131,11 @@ const ParentTable = ({
   const handleAddItem = async (newItem, setNewItem, handleCloseAddModal) => {
     try {
       if (title === TableType.STUDENTS) {
-        addItemToGenericTable(addStudent, newItem, setNewItem, "alumno", setStudents);
+        await addItemToGenericTable(addStudent, newItem, setNewItem, "alumno", setStudents);
       } else if (title === TableType.TUTORS) {
-        addItemToGenericTable(addTutor, newItem, setNewItem, "tutor/a", setTutors);
+        await addItemToGenericTable(addTutor, newItem, setNewItem, "tutor/a", setTutors);
       } else if (title === TableType.TOPICS) {
-        addItemToGenericTable(addTopic, newItem, setNewItem, "tema", setTopics);
+        await addItemToGenericTable(addTopic, newItem, setNewItem, "tema", setTopics);
       }
     } catch (err) {
       console.error(`Error when adding new ${title}:`, err);
@@ -169,12 +169,11 @@ const ParentTable = ({
   const handleEditItem = async (editedItem, setEditedItem, handleCloseEditModal) => {
     try {
       if (title === TableType.STUDENTS) {
-        editItemInGenericTable(editStudent, editedItem, setEditedItem, "alumno", setStudents);
+        await editItemInGenericTable(editStudent, editedItem, setEditedItem, "alumno", setStudents);
       } else if (title === TableType.TUTORS) {
-        editItemInGenericTable(editTutor, editedItem, setEditedItem, "tutor/a", setTutors);       
-      }
-      else if (title === TableType.TOPICS) {
-        editItemInGenericTable(editTopic, editedItem, setEditedItem, "tema", setTopics);
+        await editItemInGenericTable(editTutor, editedItem, setEditedItem, "tutor/a", setTutors);       
+      } else if (title === TableType.TOPICS) {
+        await editItemInGenericTable(editTopic, editedItem, setEditedItem, "tema", setTopics);
       }
     } catch (err) {
       console.error(`Error when editing new ${title}:`, err);

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -115,39 +115,27 @@ const ParentTable = ({
   };
   const period = useSelector((state) => state.period);
   const dispatch = useDispatch();
+  
+  const addItemToGenericTable = async (apiAddFunction, newItem, setNewItem, stringItemType, setReducer) => {
+    const item = await apiAddFunction(newItem, user, period.id); // el add
+    setNewItem({});
+    setNotification({
+      open: true,
+      message: `Se agregó ${stringItemType} exitosamente`, // 'alumno'
+      status: "success",
+    });
+    setData([...items, item]);
+    dispatch(setReducer([...items, item])); // el set
 
+  };
   const handleAddItem = async (newItem, setNewItem, handleCloseAddModal) => {
     try {
       if (title === TableType.STUDENTS) {
-        const item = await addStudent(newItem, user, period.id);
-        setNewItem({});
-        setNotification({
-          open: true,
-          message: `Alumno agregado exitosamente`,
-          status: "success",
-        });
-        setData([...items, item]);
-        dispatch(setStudents([...items, item]));
+        addItemToGenericTable(addStudent, newItem, setNewItem, "alumno", setStudents);
       } else if (title === TableType.TUTORS) {
-        const item = await addTutor(newItem, user, period.id);
-        setNewItem({});
-        setNotification({
-          open: true,
-          message: `Tutor agregado exitosamente`,
-          status: "success",
-        });
-        setData([...items, item]);
-        dispatch(setTutors([...items, item]));
+        addItemToGenericTable(addTutor, newItem, setNewItem, "tutor/a", setTutors);
       } else if (title === TableType.TOPICS) {
-        const item = await addTopic(newItem, user, period.id);
-        setNewItem({});
-        setNotification({
-          open: true,
-          message: `Tema agregado exitosamente`,
-          status: "success",
-        });
-        setData([...items, item]);
-        dispatch(setTopics([...items, item]));
+        addItemToGenericTable(addTopic, newItem, setNewItem, "tema", setTopics);
       }
     } catch (err) {
       console.error(`Error when adding new ${title}:`, err);

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -406,8 +406,16 @@ const ParentTable = ({
   };
 
   const addTutorModal = () => {
+    return innerActionTutorModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar")
+  };
+
+  const editTutorModal = () => {
+    return innerActionTutorModal(openEditModal, handleCloseEditModal, handleEdit, editedItem, setEditedItem, "Editar", "Guardar")
+  };
+
+  const innerActionTutorModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {
     return (
-      <Dialog open={openAddModal} onClose={handleCloseAddModal} maxWidth="sm" fullWidth>
+      <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
         <DialogTitle
           sx={{
             fontWeight: "bold",
@@ -417,7 +425,7 @@ const ParentTable = ({
             padding: "16px 24px",
           }}
         >
-          Agregar Nuevo Tutor
+          {TitleText} Tutor
         </DialogTitle>
         <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
           <NumericFormat
@@ -428,10 +436,10 @@ const ParentTable = ({
             autoFocus
             margin="normal"
             label="DNI o Identificación"
-            value={newItem["id"] || ""}
+            value={item["id"] || ""}
             required
             onChange={(e) =>
-              setNewItem({ ...newItem, id: parseInt(e.target.value) })
+              setItem({ ...item, id: parseInt(e.target.value) })
             }
           />
           <TextField
@@ -439,19 +447,19 @@ const ParentTable = ({
             fullWidth
             margin="normal"
             label="Nombre"
-            value={newItem["name"] || ""}
+            value={item["name"] || ""}
             required
-            onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
+            onChange={(e) => setItem({ ...item, name: e.target.value })}
           />
           <TextField
             variant="outlined"
             fullWidth
             margin="normal"
             label="Apellido"
-            value={newItem["last_name"] || ""}
+            value={item["last_name"] || ""}
             required
             onChange={(e) =>
-              setNewItem({ ...newItem, last_name: e.target.value })
+              setItem({ ...item, last_name: e.target.value })
             }
           />
           <TextField
@@ -460,9 +468,9 @@ const ParentTable = ({
             fullWidth
             margin="normal"
             variant="outlined"
-            value={newItem["email"] || ""}
+            value={item["email"] || ""}
             onChange={(e) =>
-              setNewItem({ ...newItem, email: e.target.value })
+              setItem({ ...item, email: e.target.value })
             }
             required
           />
@@ -473,19 +481,19 @@ const ParentTable = ({
             variant="outlined"
             margin="normal"
             label="Capacidad"
-            value={newItem["capacity"] || ""}
+            value={item["capacity"] || ""}
             required
             onChange={(e) =>
-              setNewItem({ ...newItem, capacity: parseInt(e.target.value) })
+              setItem({ ...item, capacity: parseInt(e.target.value) })
             }
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleCloseAddModal} variant="outlined" color="error">
+          <Button onClick={handleCloseModal} variant="outlined" color="error">
             Cancelar
           </Button>
-          <Button onClick={handleAddItem} variant="contained" color="primary">
-            Agregar
+          <Button onClick={handleConfirmAction} variant="contained" color="primary">
+            {ConfirmButtonText}
           </Button>
         </DialogActions>
       </Dialog>
@@ -673,7 +681,13 @@ const ParentTable = ({
         </>
         )
       };
-      {title === TableType.TUTORS && addTutorModal()}
+      {title === TableType.TUTORS && (
+        <>
+          {addTutorModal()}
+          {editTutorModal()}
+        </>
+        )
+      };
       {title === TableType.TOPICS && addTopicModal()}
       <MySnackbar
         open={notification.open}

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -14,20 +14,12 @@ import {
   Box,
   CircularProgress,
   Fab,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Select,
-  MenuItem,
-  InputLabel,
   Stack
 } from "@mui/material";
 import { styled } from "@mui/system";
 import { getTableData, deleteRow } from "../../../api/handleTableData";
 import { useDispatch, useSelector } from "react-redux";
 import AddIcon from "@mui/icons-material/Add";
-import { NumericFormat } from "react-number-format";
 import { addStudent, editStudent } from "../../../api/handleStudents";
 import MySnackbar from "../MySnackBar";
 import { setStudents } from "../../../redux/slices/studentsSlice";
@@ -38,6 +30,8 @@ import { addTopic, editTopic } from "../../../api/handleTopics";
 import { setTopics } from "../../../redux/slices/topicsSlice";
 import { TableType } from "./TableType";
 import { StudentModals } from "./Modals/studentModals";
+import { TutorModals } from "./Modals/tutorModals";
+import { TopicModals } from "./Modals/topicModals";
 
 const Root = styled(Paper)(({ theme }) => ({
   marginTop: theme.spacing(4),
@@ -388,13 +382,8 @@ const ParentTable = ({
           </TableContainer>
         </Root>
       </Container>
-      {title === TableType.STUDENTS && /*(
-        <>
-          {addStudentModal()}
-          {editStudentModal()}
-        </>
-        )*/
-       < StudentModals 
+      {title === TableType.STUDENTS &&
+       <StudentModals 
           openAddModal={openAddModal}
           openEditModal={openEditModal}
           setOpenAddModal={setOpenAddModal}
@@ -408,21 +397,37 @@ const ParentTable = ({
        />
 
       }; 
-      { // <--- Eliminar esta llave, está ahí solo para poder comentar tutors y topics
-      /*{title === TableType.TUTORS && (
-        <>
-          {addTutorModal()}
-          {editTutorModal()}
-        </>
-        )
-      };*/
-      /*{title === TableType.TOPICS && (
-        <>
-          {addTopicModal()}
-          {editTopicModal()}
-        </>
-        )      
-      };*/}
+      {title === TableType.TUTORS &&
+        <TutorModals 
+          openAddModal={openAddModal}
+          openEditModal={openEditModal}
+          setOpenAddModal={setOpenAddModal}
+          setOpenEditModal={setOpenEditModal}
+          handleAddItem={handleAddItem}
+          handleEditItem={handleEditItem}
+          originalEditedItemId={originalEditedItemId}
+          setOriginalEditedItemId={setOriginalEditedItemId}
+          item={itemToPassToModal}
+          setParentItem={setItemToPassToModal}
+        />
+        
+      };
+      {title === TableType.TOPICS &&
+        <TopicModals 
+          openAddModal={openAddModal}
+          openEditModal={openEditModal}
+          setOpenAddModal={setOpenAddModal}
+          setOpenEditModal={setOpenEditModal}
+          handleAddItem={handleAddItem}
+          handleEditItem={handleEditItem}
+          originalEditedItemId={originalEditedItemId}
+          setOriginalEditedItemId={setOriginalEditedItemId}
+          item={itemToPassToModal}
+          setParentItem={setItemToPassToModal}
+          tutors={tutors}
+          categories={categories}
+        />
+      };
       <MySnackbar
         open={notification.open}
         handleClose={handleSnackbarClose}

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -511,7 +511,12 @@ const ParentTable = ({
 
   const addTopicModal = () => {
     return innerActionTopicModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar");
-  }
+  };
+
+  const editTopicModal = () => {
+    return innerActionTopicModal(openEditModal, handleCloseEditModal, handleEdit, editedItem, setEditedItem, "Editar", "Guardar")
+  };
+
   const innerActionTopicModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, titleText, confirmButtonText) => {
     return (
       <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
@@ -700,7 +705,13 @@ const ParentTable = ({
         </>
         )
       };
-      {title === TableType.TOPICS && addTopicModal()}
+      {title === TableType.TOPICS && (
+        <>
+          {addTopicModal()}
+          {editTopicModal()}
+        </>
+        )      
+      };
       <MySnackbar
         open={notification.open}
         handleClose={handleSnackbarClose}

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -186,15 +186,19 @@ const ParentTable = ({
   const handleEdit = async () => {
     try {
       if (title === TableType.STUDENTS) {
-        const item = await addStudent(newItem, user, period.id);
-        setNewItem({});
+        const item = await addStudent(editedItem, user, period.id); // aux: cambiar cuando exista endpoint []
+        setEditedItem({});
         setNotification({
           open: true,
           message: `Alumno editado exitosamente`,
           status: "success",
         });
-        setData([...items, item]);
-        dispatch(setStudents([...items, item]));
+        setData((prevData) =>
+          prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem))
+        );
+        dispatch(setStudents((prevData) =>
+          prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem)))
+        );
       }
       // Esto de acá abajo que está comentado es copypaste del add
       /* else if (title === TableType.TUTORS) {
@@ -226,7 +230,7 @@ const ParentTable = ({
         status: "error",
       });
     } finally {
-      handleCloseAddModal(true);
+      handleCloseEditModal(true);
     }
     
   };

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -37,6 +37,7 @@ import { getCategories } from "../../../utils/getCategories";
 import { addTopic, editTopic } from "../../../api/handleTopics";
 import { setTopics } from "../../../redux/slices/topicsSlice";
 import { TableType } from "./TableType";
+import { StudentModals } from "./Modals/studentModals";
 
 const Root = styled(Paper)(({ theme }) => ({
   marginTop: theme.spacing(4),
@@ -65,11 +66,6 @@ const ParentTable = ({
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
-  const [openAddModal, setOpenAddModal] = useState(false);
-  const [openEditModal, setOpenEditModal] = useState(false);
-  const [newItem, setNewItem] = useState({});
-  const [editedItem, setEditedItem] = useState({}); // data
-  const [originalEditedItemId, setOriginalEditedItemId] = useState(null);
 
   const [notification, setNotification] = useState({
     open: false,
@@ -77,34 +73,9 @@ const ParentTable = ({
     status: "",
   });
 
-  const handleClickOpenAddModal = () => {
-    setOpenAddModal(true);
-  };
-
-  const handleCloseAddModal = () => {
-    setNewItem({})
-    setOpenAddModal(false);
-  };
-
-  const handleClickOpenEditModal = (item) => {
-    // Si lo que se está editando es Tutor, es necesario extraer su capacity existente de un
-    // campo especial algo estrambótico (item tiene lista de tutor_periods, cada uno con
-    // un period_id y una capacity). (Sin esto ítem no tiene capacity y falla la request).
-    if (title===TableType.TUTORS) {
-      const selectedTutorPeriod = item.tutor_periods.find(tp => tp.period_id === period.id);
-      const capacity = selectedTutorPeriod ? selectedTutorPeriod.capacity : null;
-      item["capacity"]=capacity;
-    }
-    // El id puede cambiar, así que guardamos el id original
-    setOriginalEditedItemId(item.id);
-    setEditedItem(item);
-    setOpenEditModal(true);    
-  };
-
-  const handleCloseEditModal = () => {
-    setEditedItem({})
-    setOpenEditModal(false);
-  };
+  const [openAddModal, setOpenAddModal] = useState(false);
+  const [openEditModal, setOpenEditModal] = useState(false);
+  const [originalEditedItemId, setOriginalEditedItemId] = useState(null);
 
   const user = useSelector((state) => state.user);
   const tutors = Object.values(useSelector((state) => state.tutors))
@@ -150,7 +121,7 @@ const ParentTable = ({
   const period = useSelector((state) => state.period);
   const dispatch = useDispatch();
 
-  const handleAddItem = async () => {
+  const handleAddItem = async (newItem, setNewItem, handleCloseAddModal) => {
     try {
       if (title === TableType.STUDENTS) {
         const item = await addStudent(newItem, user, period.id);
@@ -195,7 +166,7 @@ const ParentTable = ({
     }
   };
 
-  const handleEdit = async () => {
+  const handleEditItem = async (editedItem, setEditedItem, handleCloseEditModal) => {
     try {
       if (title === TableType.STUDENTS) {
         const item = await editStudent(originalEditedItemId, period.id, editedItem, user);
@@ -336,287 +307,6 @@ const ParentTable = ({
     });
   });
 
-  const addStudentModal = () => {
-    return innerActionStudentModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Agregar")
-  }
-
-  const editStudentModal = () => {
-    return innerActionStudentModal(openEditModal, handleCloseEditModal, handleEdit, editedItem, setEditedItem, "Editar", "Guardar")
-  }
-
-  const innerActionStudentModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {    
-    return (
-      <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
-        <DialogTitle
-          sx={{
-            fontWeight: "bold",
-            textAlign: "center",
-            backgroundColor: "#f5f5f5",
-            color: "#333",
-            padding: "16px 24px",
-          }}
-        >
-          {TitleText} Alumno
-        </DialogTitle>
-        <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
-          <NumericFormat
-            fullWidth
-            allowNegative={false}
-            customInput={TextField}
-            variant="outlined"
-            autoFocus
-            margin="normal"
-            label="Padrón"
-            value={item["id"] || ""}
-            required
-            onChange={(e) =>
-              setItem({ ...item, id: parseInt(e.target.value) })
-            }
-          />
-          <TextField
-            variant="outlined"
-            fullWidth
-            margin="normal"
-            label="Nombre"
-            value={item["name"] || ""}
-            required
-            onChange={(e) => setItem({ ...item, name: e.target.value })}
-          />
-          <TextField
-            variant="outlined"
-            fullWidth
-            margin="normal"
-            label="Apellido"
-            value={item["last_name"] || ""}
-            required
-            onChange={(e) =>
-              setItem({ ...item, last_name: e.target.value })
-            }
-          />
-          <TextField
-            label="Email"
-            type="email"
-            fullWidth
-            margin="normal"
-            variant="outlined"
-            value={item["email"] || ""}
-            onChange={(e) =>
-              setItem({ ...item, email: e.target.value })
-            }
-            required
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseModal} variant="outlined" color="error">
-            Cancelar
-          </Button>
-          <Button onClick={handleConfirmAction} variant="contained" color="primary">
-            {ConfirmButtonText}
-          </Button>
-        </DialogActions>
-      </Dialog>
-    )
-  };
-
-  const addTutorModal = () => {
-    return innerActionTutorModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar")
-  };
-
-  const editTutorModal = () => {
-    return innerActionTutorModal(openEditModal, handleCloseEditModal, handleEdit, editedItem, setEditedItem, "Editar", "Guardar")
-  };
-
-  const innerActionTutorModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {
-    return (
-      <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
-        <DialogTitle
-          sx={{
-            fontWeight: "bold",
-            textAlign: "center",
-            backgroundColor: "#f5f5f5",
-            color: "#333",
-            padding: "16px 24px",
-          }}
-        >
-          {TitleText} Tutor
-        </DialogTitle>
-        <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
-          <NumericFormat
-            fullWidth
-            allowNegative={false}
-            customInput={TextField}
-            variant="outlined"
-            autoFocus
-            margin="normal"
-            label="DNI o Identificación"
-            value={item["id"] || ""}
-            required
-            onChange={(e) =>
-              setItem({ ...item, id: parseInt(e.target.value) })
-            }
-          />
-          <TextField
-            variant="outlined"
-            fullWidth
-            margin="normal"
-            label="Nombre"
-            value={item["name"] || ""}
-            required
-            onChange={(e) => setItem({ ...item, name: e.target.value })}
-          />
-          <TextField
-            variant="outlined"
-            fullWidth
-            margin="normal"
-            label="Apellido"
-            value={item["last_name"] || ""}
-            required
-            onChange={(e) =>
-              setItem({ ...item, last_name: e.target.value })
-            }
-          />
-          <TextField
-            label="Email"
-            type="email"
-            fullWidth
-            margin="normal"
-            variant="outlined"
-            value={item["email"] || ""}
-            onChange={(e) =>
-              setItem({ ...item, email: e.target.value })
-            }
-            required
-          />
-          <NumericFormat
-            fullWidth
-            allowNegative={false}
-            customInput={TextField}
-            variant="outlined"
-            margin="normal"
-            label="Capacidad"
-            value={item["capacity"] || ""}
-            required
-            onChange={(e) =>
-              setItem({ ...item, capacity: parseInt(e.target.value) })
-            }
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseModal} variant="outlined" color="error">
-            Cancelar
-          </Button>
-          <Button onClick={handleConfirmAction} variant="contained" color="primary">
-            {ConfirmButtonText}
-          </Button>
-        </DialogActions>
-      </Dialog>
-    )
-  };
-
-  const addTopicModal = () => {
-    return innerActionTopicModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar Nuevo", "Agregar");
-  };
-
-  const editTopicModal = () => {
-    return innerActionTopicModal(openEditModal, handleCloseEditModal, handleEdit, editedItem, setEditedItem, "Editar", "Guardar")
-  };
-
-  const innerActionTopicModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, titleText, confirmButtonText) => {
-    return (
-      <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
-        <DialogTitle
-          sx={{
-            fontWeight: "bold",
-            textAlign: "center",
-            backgroundColor: "#f5f5f5",
-            color: "#333",
-            padding: "16px 24px",
-          }}
-        >
-          {titleText} Tema
-        </DialogTitle>
-        <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
-          <TextField
-            variant="outlined"
-            fullWidth
-            margin="normal"
-            label="Titulo"
-            value={item["name"] || ""}
-            required
-            onChange={(e) => setItem({ ...item, name: e.target.value })}
-          />
-          <InputLabel>Seleccionar categoria</InputLabel>
-          <Select
-            value={
-              item["category"] || ""
-            }
-            label="Categorías"
-            onChange={(e) =>
-              setItem({ ...item, category: e.target.value })
-            }
-            margin="normal"
-
-            sx={{ marginBottom: "8px" }}
-            required
-            fullWidth
-          >
-            <MenuItem key="" value="" disabled>
-              Seleccionar categoria
-            </MenuItem>
-            {categories.map((category) => (
-              <MenuItem key={category} value={category}>
-                {category}
-              </MenuItem>
-            ))}
-          </Select>
-          <InputLabel margin="normal">Seleccionar tutor</InputLabel>
-          <Select
-            margin="normal"
-            value={
-              item["tutor_email"] || ""
-            }
-            label="Email del tutor"
-            onChange={(e) =>
-              setItem({ ...item, tutor_email: e.target.value })
-            }
-            required
-            fullWidth
-          >
-            <MenuItem key="" value="" disabled>
-              Seleccionar tutor
-            </MenuItem>
-            {tutors.map((tutor) => (
-              <MenuItem key={tutor.id} value={tutor.email}>
-                {tutor.email}
-              </MenuItem>
-            ))}
-          </Select>
-          <NumericFormat
-            fullWidth
-            allowNegative={false}
-            customInput={TextField}
-            variant="outlined"
-            margin="normal"
-            label="Capacidad"
-            value={item["capacity"] || ""}
-            required
-            onChange={(e) =>
-              setItem({ ...item, capacity: parseInt(e.target.value) })
-            }
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseModal} variant="outlined" color="error">
-            Cancelar
-          </Button>
-          <Button onClick={handleConfirmAction} variant="contained" color="primary">
-            {confirmButtonText}
-          </Button>
-        </DialogActions>
-      </Dialog>
-    )
-  };
-
   if (loading) return <Typography variant="h6">Cargando...</Typography>;
   const categories = title === TableType.TOPICS ? getCategories(items) : [];
   return (
@@ -650,7 +340,8 @@ const ParentTable = ({
                   size="small"
                   color="primary"
                   aria-label="add"
-                  onClick={handleClickOpenAddModal}
+                  //onClick={handleClickOpenAddModal}
+                  onClick={() => setOpenAddModal(true)}
                 >
                   <AddIcon />
                 </Fab>
@@ -675,7 +366,8 @@ const ParentTable = ({
                     <TableCell>
                       <Stack direction="row" spacing={1}>
                         <Button
-                            onClick={() => handleClickOpenEditModal(item)}
+                            //onClick={() => handleClickOpenEditModal(item)}
+                            onClick={() => setOpenEditModal(true)}
                             style={{ backgroundColor: "#e0711d", color: "white" }}
                             >
                             Editar
@@ -695,27 +387,39 @@ const ParentTable = ({
           </TableContainer>
         </Root>
       </Container>
-      {title === TableType.STUDENTS && (
+      {title === TableType.STUDENTS && /*(
         <>
           {addStudentModal()}
           {editStudentModal()}
         </>
-        )
-      };
-      {title === TableType.TUTORS && (
+        )*/
+       < StudentModals 
+          openAddModal={openAddModal}
+          openEditModal={openEditModal}
+          setOpenAddModal={setOpenAddModal}
+          setOpenEditModal={setOpenEditModal}
+          handleAddItem={handleAddItem}
+          handleEditItem={handleEditItem}
+          originalEditedItemId={originalEditedItemId}
+          setOriginalEditedItemId={setOriginalEditedItemId}
+       />
+
+      }; 
+      { // <--- Eliminar esta llave, está ahí solo para poder comentar tutors y topics
+      /*{title === TableType.TUTORS && (
         <>
           {addTutorModal()}
           {editTutorModal()}
         </>
         )
-      };
-      {title === TableType.TOPICS && (
+      };*/
+      /*{title === TableType.TOPICS && (
         <>
           {addTopicModal()}
           {editTopicModal()}
         </>
         )      
-      };
+      };*/}
       <MySnackbar
         open={notification.open}
         handleClose={handleSnackbarClose}

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -87,7 +87,16 @@ const ParentTable = ({
   };
 
   const handleClickOpenEditModal = (item) => {
-    setOriginalEditedItemId(item.id)
+    // Si lo que se está editando es Tutor, es necesario extraer su capacity existente de un
+    // campo especial algo estrambótico (item tiene lista de tutor_periods, cada uno con
+    // un period_id y una capacity). (Sin esto ítem no tiene capacity y falla la request).
+    if (title=TableType.TUTORS) {
+      const selectedTutorPeriod = item.tutor_periods.find(tp => tp.period_id === period.id);
+      const capacity = selectedTutorPeriod ? selectedTutorPeriod.capacity : null;
+      item["capacity"]=capacity;
+    }
+    // El id puede cambiar, así que guardamos el id original
+    setOriginalEditedItemId(item.id);
     setEditedItem(item);
     setOpenEditModal(true);    
   };

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -90,7 +90,7 @@ const ParentTable = ({
         } else {
           setData(responseData);
         }
-        // saco esta línea: setData(responseData); y pomgo ese if else de acá arriba.
+        
         setLoading(false);
       } catch (error) {
         console.error("Error fetching data:", error);
@@ -103,8 +103,7 @@ const ParentTable = ({
 
   // Campo capacity de tutores
   useEffect(() => {
-    const addTutorCapacityField = () => {
-      console.log("hola", data);
+    const addTutorCapacityField = () => {      
       if (title === TableType.TUTORS) {
         if (!data) {
           // Seteo inicial xq hasta ahora data no vale nada
@@ -147,15 +146,15 @@ const ParentTable = ({
   const dispatch = useDispatch();
 
   const addItemToGenericTable = async (apiAddFunction, newItem, setNewItem, setReducer) => {
-    const item = await apiAddFunction(newItem, user, period.id); // el add
+    const item = await apiAddFunction(newItem, user, period.id); // add
     setNewItem({});
     setNotification({
       open: true,
-      message: `Se agregó ${TableTypeSingularLabel[title]||''} exitosamente`, // 'alumno'
+      message: `Se agregó ${TableTypeSingularLabel[title]||''} exitosamente`, // 'alumno', etc
       status: "success",
     });
     setData((prevData) => [...prevData, item]);
-    dispatch(setReducer((prevData) => [...prevData, item])); // el set
+    dispatch(setReducer((prevData) => [...prevData, item])); // set
 
   };
   const handleAddItem = async (newItem, setNewItem, handleCloseAddModal) => {
@@ -198,7 +197,6 @@ const ParentTable = ({
 
   const handleEditItem = async (editedItem, setEditedItem, handleCloseEditModal) => {
     try {
-      console.log("TUTOR item desde su PARENT:", editedItem);
       if (title === TableType.STUDENTS) {
         await editItemInGenericTable(editStudent, editedItem, setEditedItem, setStudents);
       } else if (title === TableType.TUTORS) {
@@ -288,8 +286,7 @@ const ParentTable = ({
     a.click();
     URL.revokeObjectURL(url);
   };
-
-  console.log("ANTES DE FILTEREDDATA:", data);  
+  
   // Filtrado mejorado
   const filteredData = data.filter((item) => {
     return columns.some((column) => {
@@ -299,7 +296,6 @@ const ParentTable = ({
     });
   });
 
-  console.log("DSP DE FILTEREDDATA:", data);
   if (loading) return <Typography variant="h6">Cargando...</Typography>;
   const categories = title === TableType.TOPICS ? getCategories(items) : [];
   return (
@@ -358,7 +354,7 @@ const ParentTable = ({
                     <TableCell>
                       <Stack direction="row" spacing={1}>
                         <Button
-                            onClick={() => {setOpenEditModal(true); console.log("PASANDO ITEM:", item); setItemToPassToModal(item)}}
+                            onClick={() => {setOpenEditModal(true); setItemToPassToModal(item)}}
                             style={{ backgroundColor: "#e0711d", color: "white" }} //botón naranja
                             >
                             Editar

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -28,7 +28,7 @@ import { getTableData, deleteRow } from "../../../api/handleTableData";
 import { useDispatch, useSelector } from "react-redux";
 import AddIcon from "@mui/icons-material/Add";
 import { NumericFormat } from "react-number-format";
-import { addStudent } from "../../../api/handleStudents";
+import { addStudent, editStudent } from "../../../api/handleStudents";
 import MySnackbar from "../MySnackBar";
 import { setStudents } from "../../../redux/slices/studentsSlice";
 import { addTutor } from "../../../api/handleTutors";
@@ -68,7 +68,8 @@ const ParentTable = ({
   const [openAddModal, setOpenAddModal] = useState(false);
   const [openEditModal, setOpenEditModal] = useState(false);
   const [newItem, setNewItem] = useState({});
-  const [editedItem, setEditedItem] = useState({});
+  const [editedItem, setEditedItem] = useState({}); // data
+  const [originalEditedItemId, setOriginalEditedItemId] = useState(null);
 
   const [notification, setNotification] = useState({
     open: false,
@@ -86,6 +87,7 @@ const ParentTable = ({
   };
 
   const handleClickOpenEditModal = (item) => {
+    setOriginalEditedItemId(item.id)
     setEditedItem(item);
     setOpenEditModal(true);    
   };
@@ -187,8 +189,9 @@ const ParentTable = ({
   const handleEdit = async () => {
     try {
       if (title === TableType.STUDENTS) {
-        const item = await addStudent(editedItem, user, period.id); // aux: cambiar cuando exista endpoint []
+        const item = await editStudent(originalEditedItemId, period.id, editedItem, user);
         setEditedItem({});
+        setOriginalEditedItemId(null);
         setNotification({
           open: true,
           message: `Alumno editado exitosamente`,
@@ -201,7 +204,7 @@ const ParentTable = ({
           prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem)))
         );
       }
-      // Esto de acá abajo que está comentado es copypaste del add
+      // Esto de acá abajo que está comentado es copypaste del add, lo modificaré después []
       /* else if (title === TableType.TUTORS) {
         const item = await addTutor(newItem, user, period.id);
         setNewItem({});

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -64,8 +64,10 @@ const ParentTable = ({
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
-  const [open, setOpen] = useState(false);
+  const [openAddModal, setOpenAddModal] = useState(false);
+  const [openEditModal, setOpenEditModal] = useState(false);
   const [newItem, setNewItem] = useState({});
+  const [editedItem, setEditedItem] = useState({});
 
   const [notification, setNotification] = useState({
     open: false,
@@ -73,13 +75,23 @@ const ParentTable = ({
     status: "",
   });
 
-  const handleClickOpen = () => {
-    setOpen(true);
+  const handleClickOpenAddModal = () => {
+    setOpenAddModal(true);
   };
 
-  const handleClose = () => {
+  const handleCloseAddModal = () => {
     setNewItem({})
-    setOpen(false);
+    setOpenAddModal(false);
+  };
+
+  const handleClickOpenEditModal = (item) => {
+    setEditedItem(item);
+    setOpenEditModal(true);    
+  };
+
+  const handleCloseEditModal = () => {
+    setEditedItem({})
+    setOpenEditModal(false);
   };
 
   const user = useSelector((state) => state.user);
@@ -167,9 +179,58 @@ const ParentTable = ({
         status: "error",
       });
     } finally {
-      handleClose(true);
+      handleCloseAddModal(true);
     }
   };
+
+  const handleEdit = async () => {
+    try {
+      if (title === TableType.STUDENTS) {
+        const item = await addStudent(newItem, user, period.id);
+        setNewItem({});
+        setNotification({
+          open: true,
+          message: `Alumno editado exitosamente`,
+          status: "success",
+        });
+        setData([...items, item]);
+        dispatch(setStudents([...items, item]));
+      }
+      // Esto de acá abajo que está comentado es copypaste del add
+      /* else if (title === TableType.TUTORS) {
+        const item = await addTutor(newItem, user, period.id);
+        setNewItem({});
+        setNotification({
+          open: true,
+          message: `Tutor editado exitosamente`,
+          status: "success",
+        });
+        setData([...items, item]);
+        dispatch(setTutors([...items, item]));
+      } else if (title === TableType.TOPICS) {
+        const item = await addTopic(newItem, user, period.id);
+        setNewItem({});
+        setNotification({
+          open: true,
+          message: `Tema editado exitosamente`,
+          status: "success",
+        });
+        setData([...items, item]);
+        dispatch(setTopics([...items, item]));
+      }*/
+    } catch (err) {
+      console.error(`Error when editing new ${title}:`, err);
+      setNotification({
+        open: true,
+        message: `Error al editar ${title.toLowerCase()}. Por favor, vuelva a intentar más tarde.`,
+        status: "error",
+      });
+    } finally {
+      handleCloseAddModal(true);
+    }
+    
+  };
+
   const handleDelete = async (id) => {
     try {
       // Call deleteResponse to remove the record
@@ -249,10 +310,84 @@ const ParentTable = ({
     });
   });
 
+  const editStudentModal = () => {
+    return (
+      <Dialog open={openEditModal} onClose={handleCloseEditModal} maxWidth="sm" fullWidth>
+        <DialogTitle
+          sx={{
+            fontWeight: "bold",
+            textAlign: "center",
+            backgroundColor: "#f5f5f5",
+            color: "#333",
+            padding: "16px 24px",
+          }}
+        >
+          Editar Alumno
+        </DialogTitle>
+        <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
+          <NumericFormat
+            fullWidth
+            allowNegative={false}
+            customInput={TextField}
+            variant="outlined"
+            autoFocus
+            margin="normal"
+            label="Padrón"
+            value={editedItem["id"] || ""}
+            required
+            onChange={(e) =>
+              setEditedItem({ ...editedItem, id: parseInt(e.target.value) })
+            }
+          />
+          <TextField
+            variant="outlined"
+            fullWidth
+            margin="normal"
+            label="Nombre"
+            value={editedItem["name"] || ""}
+            required
+            onChange={(e) => setEditedItem({ ...editedItem, name: e.target.value })}
+          />
+          <TextField
+            variant="outlined"
+            fullWidth
+            margin="normal"
+            label="Apellido"
+            value={editedItem["last_name"] || ""}
+            required
+            onChange={(e) =>
+              setEditedItem({ ...editedItem, last_name: e.target.value })
+            }
+          />
+          <TextField
+            label="Email"
+            type="email"
+            fullWidth
+            margin="normal"
+            variant="outlined"
+            value={editedItem["email"] || ""}
+            onChange={(e) =>
+              setEditedItem({ ...editedItem, email: e.target.value })
+            }
+            required
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseEditModal} variant="outlined" color="error">
+            Cancelar
+          </Button>
+          <Button onClick={handleEdit} variant="contained" color="primary">
+            Guardar
+          </Button>
+        </DialogActions>
+      </Dialog>
+    )
+  };
+
 
   const addStudentModal = () => {
     return (
-      <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <Dialog open={openAddModal} onClose={handleCloseAddModal} maxWidth="sm" fullWidth>
         <DialogTitle
           sx={{
             fontWeight: "bold",
@@ -313,7 +448,7 @@ const ParentTable = ({
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} variant="outlined" color="error">
+          <Button onClick={handleCloseAddModal} variant="outlined" color="error">
             Cancelar
           </Button>
           <Button onClick={handleAddItem} variant="contained" color="primary">
@@ -326,7 +461,7 @@ const ParentTable = ({
 
   const addTutorModal = () => {
     return (
-      <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <Dialog open={openAddModal} onClose={handleCloseAddModal} maxWidth="sm" fullWidth>
         <DialogTitle
           sx={{
             fontWeight: "bold",
@@ -400,7 +535,7 @@ const ParentTable = ({
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} variant="outlined" color="error">
+          <Button onClick={handleCloseAddModal} variant="outlined" color="error">
             Cancelar
           </Button>
           <Button onClick={handleAddItem} variant="contained" color="primary">
@@ -413,7 +548,7 @@ const ParentTable = ({
 
   const addTopicModal = () => {
     return (
-      <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <Dialog open={openAddModal} onClose={handleCloseAddModal} maxWidth="sm" fullWidth>
         <DialogTitle
           sx={{
             fontWeight: "bold",
@@ -496,7 +631,7 @@ const ParentTable = ({
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} variant="outlined" color="error">
+          <Button onClick={handleCloseAddModal} variant="outlined" color="error">
             Cancelar
           </Button>
           <Button onClick={handleAddItem} variant="contained" color="primary">
@@ -540,7 +675,7 @@ const ParentTable = ({
                   size="small"
                   color="primary"
                   aria-label="add"
-                  onClick={handleClickOpen}
+                  onClick={handleClickOpenAddModal}
                 >
                   <AddIcon />
                 </Fab>
@@ -563,6 +698,12 @@ const ParentTable = ({
                   <TableRow key={item.id}>
                     {renderRow(item, rowKeys)}
                     <TableCell>
+                    <Button
+                        onClick={() => handleClickOpenEditModal(item)}
+                        style={{ backgroundColor: "orange", color: "white" }}
+                      >
+                        Editar
+                      </Button>
                       <Button
                         onClick={() => handleDelete(item.id)}
                         style={{ backgroundColor: "red", color: "white" }}
@@ -577,7 +718,13 @@ const ParentTable = ({
           </TableContainer>
         </Root>
       </Container>
-      {title === TableType.STUDENTS && addStudentModal()}
+      {title === TableType.STUDENTS && (
+        <>
+          {addStudentModal()}
+          {editStudentModal()}
+        </>
+        )
+      };
       {title === TableType.TUTORS && addTutorModal()}
       {title === TableType.TOPICS && addTopicModal()}
       <MySnackbar

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -115,7 +115,7 @@ const ParentTable = ({
   };
   const period = useSelector((state) => state.period);
   const dispatch = useDispatch();
-  
+
   const addItemToGenericTable = async (apiAddFunction, newItem, setNewItem, stringItemType, setReducer) => {
     const item = await apiAddFunction(newItem, user, period.id); // el add
     setNewItem({});
@@ -149,54 +149,32 @@ const ParentTable = ({
     }
   };
 
+  const editItemInGenericTable = async (apiEditFunction, editedItem, setEditedItem, stringItemType, setReducer) => {
+    const item = await apiEditFunction(originalEditedItemId, period.id, editedItem, user);
+    setEditedItem({});
+    setOriginalEditedItemId(null);
+    setNotification({
+      open: true,
+      message: `Se editó ${stringItemType} exitosamente`,
+      status: "success",
+    });
+    setData((prevData) =>
+      prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem))
+    );
+    dispatch(setReducer((prevData) =>
+      prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem)))
+    );
+  }
+
   const handleEditItem = async (editedItem, setEditedItem, handleCloseEditModal) => {
     try {
       if (title === TableType.STUDENTS) {
-        const item = await editStudent(originalEditedItemId, period.id, editedItem, user);
-        setEditedItem({});
-        setOriginalEditedItemId(null);
-        setNotification({
-          open: true,
-          message: `Alumno editado exitosamente`,
-          status: "success",
-        });
-        setData((prevData) =>
-          prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem))
-        );
-        dispatch(setStudents((prevData) =>
-          prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem)))
-        );
+        editItemInGenericTable(editStudent, editedItem, setEditedItem, "alumno", setStudents);
       } else if (title === TableType.TUTORS) {
-        const item = await editTutor(originalEditedItemId, period.id, editedItem, user);
-        setEditedItem({});
-        setOriginalEditedItemId(null);
-        setNotification({
-          open: true,
-          message: `Tutor editado exitosamente`,
-          status: "success",
-        });
-        setData((prevData) =>
-          prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem))
-        );
-        dispatch(setStudents((prevData) =>
-          prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem)))
-        );
+        editItemInGenericTable(editTutor, editedItem, setEditedItem, "tutor/a", setTutors);       
       }
       else if (title === TableType.TOPICS) {
-        const item = await editTopic(originalEditedItemId, period.id, editedItem, user); //[]
-        setEditedItem({});
-        setOriginalEditedItemId(null);
-        setNotification({
-          open: true,
-          message: `Tema editado exitosamente`,
-          status: "success",
-        });
-        setData((prevData) =>
-          prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem))
-        );
-        dispatch(setStudents((prevData) =>
-          prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem)))
-        );
+        editItemInGenericTable(editTopic, editedItem, setEditedItem, "tema", setTopics);
       }
     } catch (err) {
       console.error(`Error when editing new ${title}:`, err);

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -21,6 +21,7 @@ import {
   Select,
   MenuItem,
   InputLabel,
+  Stack
 } from "@mui/material";
 import { styled } from "@mui/system";
 import { getTableData, deleteRow } from "../../../api/handleTableData";
@@ -376,7 +377,7 @@ const ParentTable = ({
             required
           />
         </DialogContent>
-        <DialogActions>
+        <DialogActions sx={{ border: 5 }}>
           <Button onClick={handleCloseEditModal} variant="outlined" color="error">
             Cancelar
           </Button>
@@ -702,18 +703,20 @@ const ParentTable = ({
                   <TableRow key={item.id}>
                     {renderRow(item, rowKeys)}
                     <TableCell>
-                    <Button
-                        onClick={() => handleClickOpenEditModal(item)}
-                        style={{ backgroundColor: "orange", color: "white" }}
-                      >
-                        Editar
-                      </Button>
-                      <Button
-                        onClick={() => handleDelete(item.id)}
-                        style={{ backgroundColor: "red", color: "white" }}
-                      >
-                        Eliminar
-                      </Button>
+                      <Stack direction="row" spacing={1}>
+                        <Button
+                            onClick={() => handleClickOpenEditModal(item)}
+                            style={{ backgroundColor: "#e0711d", color: "white" }}
+                            >
+                            Editar
+                          </Button>
+                          <Button
+                            onClick={() => handleDelete(item.id)}
+                            style={{ backgroundColor: "red", color: "white" }}
+                            >
+                            Eliminar
+                          </Button>
+                        </Stack>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -334,8 +334,7 @@ const ParentTable = ({
                 <Fab
                   size="small"
                   color="primary"
-                  aria-label="add"
-                  //onClick={handleClickOpenAddModal}
+                  aria-label="add"                  
                   onClick={() => setOpenAddModal(true)}
                 >
                   <AddIcon />
@@ -361,7 +360,6 @@ const ParentTable = ({
                     <TableCell>
                       <Stack direction="row" spacing={1}>
                         <Button
-                            //onClick={() => handleClickOpenEditModal(item)}
                             onClick={() => {setOpenEditModal(true); setItemToPassToModal(item)}}
                             style={{ backgroundColor: "#e0711d", color: "white" }}
                             >

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -35,6 +35,7 @@ import { setTutors } from "../../../redux/slices/tutorsSlice";
 import { getCategories } from "../../../utils/getCategories";
 import { addTopic } from "../../../api/handleTopics";
 import { setTopics } from "../../../redux/slices/topicsSlice";
+import { TableType } from "./TableType";
 
 const Root = styled(Paper)(({ theme }) => ({
   marginTop: theme.spacing(4),
@@ -127,7 +128,7 @@ const ParentTable = ({
 
   const handleAddItem = async () => {
     try {
-      if (title === "Alumnos") {
+      if (title === TableType.STUDENTS) {
         const item = await addStudent(newItem, user, period.id);
         setNewItem({});
         setNotification({
@@ -137,7 +138,7 @@ const ParentTable = ({
         });
         setData([...items, item]);
         dispatch(setStudents([...items, item]));
-      } else if (title === "Tutores") {
+      } else if (title === TableType.TUTORS) {
         const item = await addTutor(newItem, user, period.id);
         setNewItem({});
         setNotification({
@@ -147,7 +148,7 @@ const ParentTable = ({
         });
         setData([...items, item]);
         dispatch(setTutors([...items, item]));
-      } else if (title === "Temas") {
+      } else if (title === TableType.TOPICS) {
         const item = await addTopic(newItem, user, period.id);
         setNewItem({});
         setNotification({
@@ -247,7 +248,8 @@ const ParentTable = ({
       return String(itemValue).toLowerCase().includes(searchTerm.toLowerCase());
     });
   });
-  
+
+
   const addStudentModal = () => {
     return (
       <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
@@ -320,7 +322,7 @@ const ParentTable = ({
         </DialogActions>
       </Dialog>
     )
-  }
+  };
 
   const addTutorModal = () => {
     return (
@@ -407,7 +409,7 @@ const ParentTable = ({
         </DialogActions>
       </Dialog>
     )
-  }
+  };
 
   const addTopicModal = () => {
     return (
@@ -503,10 +505,10 @@ const ParentTable = ({
         </DialogActions>
       </Dialog>
     )
-  }
+  };
 
   if (loading) return <Typography variant="h6">Cargando...</Typography>;
-  const categories = title === "Temas" ? getCategories(items) : [];
+  const categories = title === TableType.TOPICS ? getCategories(items) : [];
   return (
     <>
       <Container maxWidth="lg">
@@ -575,9 +577,9 @@ const ParentTable = ({
           </TableContainer>
         </Root>
       </Container>
-      {title === "Alumnos" && addStudentModal()}
-      {title === "Tutores" && addTutorModal()}
-      {title === "Temas" && addTopicModal()}
+      {title === TableType.STUDENTS && addStudentModal()}
+      {title === TableType.TUTORS && addTutorModal()}
+      {title === TableType.TOPICS && addTopicModal()}
       <MySnackbar
         open={notification.open}
         handleClose={handleSnackbarClose}

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -323,84 +323,17 @@ const ParentTable = ({
     });
   });
 
-  const editStudentModal = () => {
-    return (
-      <Dialog open={openEditModal} onClose={handleCloseEditModal} maxWidth="sm" fullWidth>
-        <DialogTitle
-          sx={{
-            fontWeight: "bold",
-            textAlign: "center",
-            backgroundColor: "#f5f5f5",
-            color: "#333",
-            padding: "16px 24px",
-          }}
-        >
-          Editar Alumno
-        </DialogTitle>
-        <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
-          <NumericFormat
-            fullWidth
-            allowNegative={false}
-            customInput={TextField}
-            variant="outlined"
-            autoFocus
-            margin="normal"
-            label="Padrón"
-            value={editedItem["id"] || ""}
-            required
-            onChange={(e) =>
-              setEditedItem({ ...editedItem, id: parseInt(e.target.value) })
-            }
-          />
-          <TextField
-            variant="outlined"
-            fullWidth
-            margin="normal"
-            label="Nombre"
-            value={editedItem["name"] || ""}
-            required
-            onChange={(e) => setEditedItem({ ...editedItem, name: e.target.value })}
-          />
-          <TextField
-            variant="outlined"
-            fullWidth
-            margin="normal"
-            label="Apellido"
-            value={editedItem["last_name"] || ""}
-            required
-            onChange={(e) =>
-              setEditedItem({ ...editedItem, last_name: e.target.value })
-            }
-          />
-          <TextField
-            label="Email"
-            type="email"
-            fullWidth
-            margin="normal"
-            variant="outlined"
-            value={editedItem["email"] || ""}
-            onChange={(e) =>
-              setEditedItem({ ...editedItem, email: e.target.value })
-            }
-            required
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseEditModal} variant="outlined" color="error">
-            Cancelar
-          </Button>
-          <Button onClick={handleEdit} variant="contained" color="primary">
-            Guardar
-          </Button>
-        </DialogActions>
-      </Dialog>
-    )
-  };
-
-
   const addStudentModal = () => {
+    return innerActionStudentModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Agregar")
+  }
+
+  const editStudentModal = () => {
+    return innerActionStudentModal(openEditModal, handleCloseEditModal, handleEdit, editedItem, setEditedItem, "Editar", "Guardar")
+  }
+
+  const innerActionStudentModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {    
     return (
-      <Dialog open={openAddModal} onClose={handleCloseAddModal} maxWidth="sm" fullWidth>
+      <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
         <DialogTitle
           sx={{
             fontWeight: "bold",
@@ -410,7 +343,7 @@ const ParentTable = ({
             padding: "16px 24px",
           }}
         >
-          Agregar Nuevo Alumno
+          {TitleText} Alumno
         </DialogTitle>
         <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
           <NumericFormat
@@ -421,10 +354,10 @@ const ParentTable = ({
             autoFocus
             margin="normal"
             label="Padrón"
-            value={newItem["id"] || ""}
+            value={item["id"] || ""}
             required
             onChange={(e) =>
-              setNewItem({ ...newItem, id: parseInt(e.target.value) })
+              setItem({ ...item, id: parseInt(e.target.value) })
             }
           />
           <TextField
@@ -432,19 +365,19 @@ const ParentTable = ({
             fullWidth
             margin="normal"
             label="Nombre"
-            value={newItem["name"] || ""}
+            value={item["name"] || ""}
             required
-            onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
+            onChange={(e) => setItem({ ...item, name: e.target.value })}
           />
           <TextField
             variant="outlined"
             fullWidth
             margin="normal"
             label="Apellido"
-            value={newItem["last_name"] || ""}
+            value={item["last_name"] || ""}
             required
             onChange={(e) =>
-              setNewItem({ ...newItem, last_name: e.target.value })
+              setItem({ ...item, last_name: e.target.value })
             }
           />
           <TextField
@@ -453,19 +386,19 @@ const ParentTable = ({
             fullWidth
             margin="normal"
             variant="outlined"
-            value={newItem["email"] || ""}
+            value={item["email"] || ""}
             onChange={(e) =>
-              setNewItem({ ...newItem, email: e.target.value })
+              setItem({ ...item, email: e.target.value })
             }
             required
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleCloseAddModal} variant="outlined" color="error">
+          <Button onClick={handleCloseModal} variant="outlined" color="error">
             Cancelar
           </Button>
-          <Button onClick={handleAddItem} variant="contained" color="primary">
-            Agregar
+          <Button onClick={handleConfirmAction} variant="contained" color="primary">
+            {ConfirmButtonText}
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -380,7 +380,7 @@ const ParentTable = ({
             required
           />
         </DialogContent>
-        <DialogActions sx={{ border: 5 }}>
+        <DialogActions>
           <Button onClick={handleCloseEditModal} variant="outlined" color="error">
             Cancelar
           </Button>

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -90,7 +90,7 @@ const ParentTable = ({
     // Si lo que se está editando es Tutor, es necesario extraer su capacity existente de un
     // campo especial algo estrambótico (item tiene lista de tutor_periods, cada uno con
     // un period_id y una capacity). (Sin esto ítem no tiene capacity y falla la request).
-    if (title=TableType.TUTORS) {
+    if (title===TableType.TUTORS) {
       const selectedTutorPeriod = item.tutor_periods.find(tp => tp.period_id === period.id);
       const capacity = selectedTutorPeriod ? selectedTutorPeriod.capacity : null;
       item["capacity"]=capacity;

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -322,12 +322,196 @@ const ParentTable = ({
     )
   }
 
+  const addTutorModal = () => {
+    return (
+      <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+        <DialogTitle
+          sx={{
+            fontWeight: "bold",
+            textAlign: "center",
+            backgroundColor: "#f5f5f5",
+            color: "#333",
+            padding: "16px 24px",
+          }}
+        >
+          Agregar Nuevo Tutor
+        </DialogTitle>
+        <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
+          <NumericFormat
+            fullWidth
+            allowNegative={false}
+            customInput={TextField}
+            variant="outlined"
+            autoFocus
+            margin="normal"
+            label="DNI o Identificación"
+            value={newItem["id"] || ""}
+            required
+            onChange={(e) =>
+              setNewItem({ ...newItem, id: parseInt(e.target.value) })
+            }
+          />
+          <TextField
+            variant="outlined"
+            fullWidth
+            margin="normal"
+            label="Nombre"
+            value={newItem["name"] || ""}
+            required
+            onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
+          />
+          <TextField
+            variant="outlined"
+            fullWidth
+            margin="normal"
+            label="Apellido"
+            value={newItem["last_name"] || ""}
+            required
+            onChange={(e) =>
+              setNewItem({ ...newItem, last_name: e.target.value })
+            }
+          />
+          <TextField
+            label="Email"
+            type="email"
+            fullWidth
+            margin="normal"
+            variant="outlined"
+            value={newItem["email"] || ""}
+            onChange={(e) =>
+              setNewItem({ ...newItem, email: e.target.value })
+            }
+            required
+          />
+          <NumericFormat
+            fullWidth
+            allowNegative={false}
+            customInput={TextField}
+            variant="outlined"
+            margin="normal"
+            label="Capacidad"
+            value={newItem["capacity"] || ""}
+            required
+            onChange={(e) =>
+              setNewItem({ ...newItem, capacity: parseInt(e.target.value) })
+            }
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} variant="outlined" color="error">
+            Cancelar
+          </Button>
+          <Button onClick={handleAddItem} variant="contained" color="primary">
+            Agregar
+          </Button>
+        </DialogActions>
+      </Dialog>
+    )
+  }
+
+  const addTopicModal = () => {
+    return (
+      <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+        <DialogTitle
+          sx={{
+            fontWeight: "bold",
+            textAlign: "center",
+            backgroundColor: "#f5f5f5",
+            color: "#333",
+            padding: "16px 24px",
+          }}
+        >
+          Agregar Nuevo Tema
+        </DialogTitle>
+        <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
+          <TextField
+            variant="outlined"
+            fullWidth
+            margin="normal"
+            label="Titulo"
+            value={newItem["name"] || ""}
+            required
+            onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
+          />
+          <InputLabel>Seleccionar categoria</InputLabel>
+          <Select
+            value={
+              newItem["category"] || ""
+            }
+            label="Categorías"
+            onChange={(e) =>
+              setNewItem({ ...newItem, category: e.target.value })
+            }
+            margin="normal"
+
+            sx={{ marginBottom: "8px" }}
+            required
+            fullWidth
+          >
+            <MenuItem key="" value="" disabled>
+              Seleccionar categoria
+            </MenuItem>
+            {categories.map((category) => (
+              <MenuItem key={category} value={category}>
+                {category}
+              </MenuItem>
+            ))}
+          </Select>
+          <InputLabel margin="normal">Seleccionar tutor</InputLabel>
+          <Select
+            margin="normal"
+            value={
+              newItem["tutor_email"] || ""
+            }
+            label="Email del tutor"
+            onChange={(e) =>
+              setNewItem({ ...newItem, tutor_email: e.target.value })
+            }
+            required
+            fullWidth
+          >
+            <MenuItem key="" value="" disabled>
+              Seleccionar tutor
+            </MenuItem>
+            {tutors.map((tutor) => (
+              <MenuItem key={tutor.id} value={tutor.email}>
+                {tutor.email}
+              </MenuItem>
+            ))}
+          </Select>
+          <NumericFormat
+            fullWidth
+            allowNegative={false}
+            customInput={TextField}
+            variant="outlined"
+            margin="normal"
+            label="Capacidad"
+            value={newItem["capacity"] || ""}
+            required
+            onChange={(e) =>
+              setNewItem({ ...newItem, capacity: parseInt(e.target.value) })
+            }
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} variant="outlined" color="error">
+            Cancelar
+          </Button>
+          <Button onClick={handleAddItem} variant="contained" color="primary">
+            Agregar
+          </Button>
+        </DialogActions>
+      </Dialog>
+    )
+  }
+
   if (loading) return <Typography variant="h6">Cargando...</Typography>;
   const categories = title === "Temas" ? getCategories(items) : [];
   return (
     <>
       <Container maxWidth="lg">
         <Root>
+          {/* --- Header --- */}
           <Title variant="h4">{title}</Title>
           <TextField
             label="Buscar"
@@ -371,6 +555,7 @@ const ParentTable = ({
                   <TableCell>Acciones</TableCell>
                 </TableRow>
               </TableHead>
+              {/* --- Content --- */}
               <TableBody>
                 {filteredData.map((item) => (
                   <TableRow key={item.id}>
@@ -391,185 +576,8 @@ const ParentTable = ({
         </Root>
       </Container>
       {title === "Alumnos" && addStudentModal()}
-
-      {title === "Tutores" && (
-        <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-          <DialogTitle
-            sx={{
-              fontWeight: "bold",
-              textAlign: "center",
-              backgroundColor: "#f5f5f5",
-              color: "#333",
-              padding: "16px 24px",
-            }}
-          >
-            Agregar Nuevo Tutor
-          </DialogTitle>
-          <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
-            <NumericFormat
-              fullWidth
-              allowNegative={false}
-              customInput={TextField}
-              variant="outlined"
-              autoFocus
-              margin="normal"
-              label="DNI o Identificación"
-              value={newItem["id"] || ""}
-              required
-              onChange={(e) =>
-                setNewItem({ ...newItem, id: parseInt(e.target.value) })
-              }
-            />
-            <TextField
-              variant="outlined"
-              fullWidth
-              margin="normal"
-              label="Nombre"
-              value={newItem["name"] || ""}
-              required
-              onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
-            />
-            <TextField
-              variant="outlined"
-              fullWidth
-              margin="normal"
-              label="Apellido"
-              value={newItem["last_name"] || ""}
-              required
-              onChange={(e) =>
-                setNewItem({ ...newItem, last_name: e.target.value })
-              }
-            />
-            <TextField
-              label="Email"
-              type="email"
-              fullWidth
-              margin="normal"
-              variant="outlined"
-              value={newItem["email"] || ""}
-              onChange={(e) =>
-                setNewItem({ ...newItem, email: e.target.value })
-              }
-              required
-            />
-            <NumericFormat
-              fullWidth
-              allowNegative={false}
-              customInput={TextField}
-              variant="outlined"
-              margin="normal"
-              label="Capacidad"
-              value={newItem["capacity"] || ""}
-              required
-              onChange={(e) =>
-                setNewItem({ ...newItem, capacity: parseInt(e.target.value) })
-              }
-            />
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={handleClose} variant="outlined" color="error">
-              Cancelar
-            </Button>
-            <Button onClick={handleAddItem} variant="contained" color="primary">
-              Agregar
-            </Button>
-          </DialogActions>
-        </Dialog>
-      )}
-
-      {title === "Temas" && (
-        <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-          <DialogTitle
-            sx={{
-              fontWeight: "bold",
-              textAlign: "center",
-              backgroundColor: "#f5f5f5",
-              color: "#333",
-              padding: "16px 24px",
-            }}
-          >
-            Agregar Nuevo Tema
-          </DialogTitle>
-          <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
-            <TextField
-              variant="outlined"
-              fullWidth
-              margin="normal"
-              label="Titulo"
-              value={newItem["name"] || ""}
-              required
-              onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
-            />
-            <InputLabel>Seleccionar categoria</InputLabel>
-            <Select
-              value={
-                newItem["category"] || ""
-              }
-              label="Categorías"
-              onChange={(e) =>
-                setNewItem({ ...newItem, category: e.target.value })
-              }
-              margin="normal"
-
-              sx={{ marginBottom: "8px" }}
-              required
-              fullWidth
-            >
-              <MenuItem key="" value="" disabled>
-                Seleccionar categoria
-              </MenuItem>
-              {categories.map((category) => (
-                <MenuItem key={category} value={category}>
-                  {category}
-                </MenuItem>
-              ))}
-            </Select>
-            <InputLabel margin="normal">Seleccionar tutor</InputLabel>
-            <Select
-              margin="normal"
-              value={
-                newItem["tutor_email"] || ""
-              }
-              label="Email del tutor"
-              onChange={(e) =>
-                setNewItem({ ...newItem, tutor_email: e.target.value })
-              }
-              required
-              fullWidth
-            >
-              <MenuItem key="" value="" disabled>
-                Seleccionar tutor
-              </MenuItem>
-              {tutors.map((tutor) => (
-                <MenuItem key={tutor.id} value={tutor.email}>
-                  {tutor.email}
-                </MenuItem>
-              ))}
-            </Select>
-            <NumericFormat
-              fullWidth
-              allowNegative={false}
-              customInput={TextField}
-              variant="outlined"
-              margin="normal"
-              label="Capacidad"
-              value={newItem["capacity"] || ""}
-              required
-              onChange={(e) =>
-                setNewItem({ ...newItem, capacity: parseInt(e.target.value) })
-              }
-            />
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={handleClose} variant="outlined" color="error">
-              Cancelar
-            </Button>
-            <Button onClick={handleAddItem} variant="contained" color="primary">
-              Agregar
-            </Button>
-          </DialogActions>
-        </Dialog>
-      )}
+      {title === "Tutores" && addTutorModal()}
+      {title === "Temas" && addTopicModal()}
       <MySnackbar
         open={notification.open}
         handleClose={handleSnackbarClose}

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -31,7 +31,7 @@ import { NumericFormat } from "react-number-format";
 import { addStudent, editStudent } from "../../../api/handleStudents";
 import MySnackbar from "../MySnackBar";
 import { setStudents } from "../../../redux/slices/studentsSlice";
-import { addTutor } from "../../../api/handleTutors";
+import { addTutor, editTutor } from "../../../api/handleTutors";
 import { setTutors } from "../../../redux/slices/tutorsSlice";
 import { getCategories } from "../../../utils/getCategories";
 import { addTopic } from "../../../api/handleTopics";
@@ -203,19 +203,24 @@ const ParentTable = ({
         dispatch(setStudents((prevData) =>
           prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem)))
         );
-      }
-      // Esto de acá abajo que está comentado es copypaste del add, lo modificaré después []
-      /* else if (title === TableType.TUTORS) {
-        const item = await addTutor(newItem, user, period.id);
-        setNewItem({});
+      } else if (title === TableType.TUTORS) {
+        const item = await editTutor(originalEditedItemId, period.id, editedItem, user);
+        setEditedItem({});
+        setOriginalEditedItemId(null);
         setNotification({
           open: true,
           message: `Tutor editado exitosamente`,
           status: "success",
         });
-        setData([...items, item]);
-        dispatch(setTutors([...items, item]));
-      } else if (title === TableType.TOPICS) {
+        setData((prevData) =>
+          prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem))
+        );
+        dispatch(setStudents((prevData) =>
+          prevData.map((existingItem) => (existingItem.id === item.id ? item : existingItem)))
+        );
+      }
+      // Esto de acá abajo que está comentado es copypaste del add, lo modificaré después []
+      /* else if (title === TableType.TOPICS) {
         const item = await addTopic(newItem, user, period.id);
         setNewItem({});
         setNotification({

--- a/src/components/UI/Tables/TableType.js
+++ b/src/components/UI/Tables/TableType.js
@@ -1,0 +1,6 @@
+// Enum en reactjs
+export const TableType = Object.freeze({
+    STUDENTS: "Alumnos",
+    TUTORS: "Tutores",
+    TOPICS: "Temas"
+});

--- a/src/components/UI/Tables/TableType.js
+++ b/src/components/UI/Tables/TableType.js
@@ -4,3 +4,9 @@ export const TableType = Object.freeze({
     TUTORS: "Tutores",
     TOPICS: "Temas"
 });
+
+export const TableTypeSingularLabel = {
+    [TableType.STUDENTS]: "alumno",
+    [TableType.TUTORS]: "tutor/a",
+    [TableType.TOPICS]: "tema",
+};

--- a/src/utils/addCapacityToTutors.js
+++ b/src/utils/addCapacityToTutors.js
@@ -1,0 +1,10 @@
+
+// Recibe una lista en la que cada elemento es tutor, devuelve una lista 
+export const addCapacityToTutors = (tutorsList, period) => {
+
+ return tutorsList.map((item) => { // Agrega capacity a cada tutor
+    const selectedTutorPeriod = item.tutor_periods.find(tp => tp.period_id === period.id);
+    const capacity = selectedTutorPeriod ? selectedTutorPeriod.capacity : null;
+    return {...item, capacity};
+  });
+}


### PR DESCRIPTION
# Nuevas funcionalidades (3 ediciones) y refactor a esa parte
Explico.

# Nuevas funcionalidades
Acá las listo.
## Edición de Estudiante
**Nuevo modal (basado en el que ya existía para Agregar estudiante) con su botón para editar estudiante, y la comunicación necesaria con el back para realizar la edición.**
Esto **se ve desde el front, desde rol de admin, al entrar y seleccionar un cuatrimestre, clickeando** uno de los cuatro rectángulos azules: el que dice **Alumnos**.
## Edición de Tutor
**Ídem** estudiante pero para tutor, basado en agregar tutor que ya existía.
## Edición de Tema
**Ídem** estudiante pero para tema, basado en agregar tema que ya existía.
- Obs: el endpoint de editar tema no existe todavía, pero dejo todo listo en el front, e inhabilito el botón que confirma el modal hasta que agregue ese endpoint.

## Refactor
Primero una breve intro: hay un archivo que se llama ParentTable, manejaba y continúa manejando todos estos modals de Agregar y de Editar, para Estudiante / Tutor / Tema. Fin intro, xd.

Mientras agregaba estas funcionalidades noté algunas cosas:
- **cada vez que se tipeaba una letra en cualquier campo** de cualquiera de esos modales (tanto los nuevos de "Editar" como los que Ya Existían de "Agregar"), la letra aparecía en el front pero con **MUCHO lag**, Encontré que era un tema de que el "item" (la 'variable') en que se guardaba lo editado, era un useState que poseía ParentTable que es el archivo que maneja todo esto, por lo que Cada Vez que se tipeaba una letra, ese archivo se volvía a renderizar y por eso era todo tan lento / laggueado.
- **además**, ya antes de entender eso se notaba que quedaba muy **copypasteado** el código del **modal Editar estudiante respecto al de Agregar estudiante.**
Por estos dos motivos, se hizo un **refactor**:
- **Se extrajo la parte en común** del modal de Agregar estudiante y Editar estudiante, y se la reutiliza. Ídem caso tutor. Ídem caso tema.
- También se extrajeron **"funciones" comunes** a un custom hook que usan todos los modals (para reutilizar, también).
Con este refactor quedó mejor (**reutilización** en lugar de copypaste) **y sí se solucionó el problema del lag al tipear :D.**

## Además!
- todos estos modals (Agregar / Editar de Estudiante / Tema / Tutor) **ahora permiten presionar Enter para confirmar** la accion :) (antes apretar enter con el modal abierto no hacía nada).
- **y le agregué autofocus al primer campo**, al único de estos modals que no tenía (los demás ya tenían) :). El autofocus es lo que hace que ya tengas el cursor titilando en el primer campo del modal ya listo para escribir (mientras que si no tenés autofocus, primero tenés que hacer click en el campo para posicionar ahí el cursor).

## Por último, Mini refactor
En este mismo archivo en cuestión, ParentTable, al agregar estos tres edit había que llamar a los endpoints nuevos.
ParentTable tenía tres valores posibles de "title" (en realidad son más, pero 3 son los relevantes para esto) y tiene ifs que checkean su valor para abrir los modals correspondientes.
- las llamadas se hacen en un archivo aparte, en carpeta "api", análogamente a como estaba hecho el add que ya existía
- la función en ParentTable que se ejecuta al confirmar un modal de agregar, **tenía tres ramas según title** sea Alumnos o Tutors o Temas. **Se la refactorizó un poco para evitar repetición** de código. E ídem con la función al confirmar la Edición de esas tres cosas.

   El archivo ParentTable bajó considerablemente su cantidad de líneas con estos refactors (que extraen y reutilizan código).

- Los **tres valores de "title"** se leen en ParentTable pero se setean en otros archivos (ya estaba así). Es por esto que **se pusieron en un enum**, para usarlos como **constantes** y no tener miedo de errores de tipeo
- **Los mensajes de éxito y error decían cosas gramaticalmente incorrectas** (ej "el alumnos" y similares), esto ocurría xq los "title" están en plural pero acá necesitábamos el singular. Dado que pasar a singular no es trivial (no alcanza con remover una "s" xq -s o -es), **se agregó un diccionario** que para cada valor de "title" devuelve lo mismo pero en singular. De esta forma evitamos cada palabra hardcodeada en varios lugares.

--- 

### Comentarios
Cuestiones conocidas
- editar tema tiene el botón deshabilitado (no permite clickearlo) xq no existe el endpoint, se habilitará cuando exista.
- confirmar edición de estudiante tarda más de lo que debería. Estuve viendo y parece un tema con los set y los useState, y esto también afecta a los Agregar que ya existían. Hacerlo ahora aumentaría mucho el tiempo en que esta rama diverge de la principal (que ya se me extendió bastante). Está previsto un refactor en otra iteración para mejorar esto.
- getCapacities: hay un parseo de la capacity de cada tutor recibida, es necesario, en futuras iteraciones se tendría que ver si emprolijarlo un poco (actualmente tiene una función en utils para hacerlo, pero todavía es mejorable en el futuro).

### Pruebas desde el front
Probé todas, las Editar, y también las tres Agregar que ya existían por las dudas xq ahora ambas variantes usan la misma base reutilizable.
**Todo bien :).**

--- 
Es front del issue tpf-v2/assignment-service#22.

**P/D:**
**Acéptenme el PR, que tengo otro en camino acá en el front en el que cambio los "alumno(s)" y "grupo(s)" por "estudiante(s)" y "equipo(s)" respectivamente :).**