### PR TITLE
Feat/editar tema

### DIFF
--- a/src/components/UI/Tables/ChildTables/TopicsTable.js
+++ b/src/components/UI/Tables/ChildTables/TopicsTable.js
@@ -30,7 +30,7 @@ const TopicsTable = () => {
 
 
   return (
-    <ParentTable title={title} columns={columns} rowKeys={rowKeys} endpoint={endpoint} renderRow={renderRow} items={topics} enableEdit={false}/>
+    <ParentTable title={title} columns={columns} rowKeys={rowKeys} endpoint={endpoint} renderRow={renderRow} items={topics} enableEdit={true}/>
   );
 };
 

--- a/src/components/UI/Tables/Modals/studentModals.js
+++ b/src/components/UI/Tables/Modals/studentModals.js
@@ -42,7 +42,7 @@ export const StudentModals = ({
           setParentItem: setParentItem
       });
 
-      /////// Modals de Estudiante ///////
+      /////// Modals ///////
       const innerActionStudentModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>

--- a/src/components/UI/Tables/Modals/topicModals.js
+++ b/src/components/UI/Tables/Modals/topicModals.js
@@ -76,18 +76,18 @@ export const TopicModals = ({
                   fullWidth
                   margin="normal"
                   label="Titulo"
-                  value={item["name"] || ""}
+                  value={item.name || ""}
                   required
                   onChange={(e) => setItem({ ...item, name: e.target.value })}
                 />
                 <InputLabel>Seleccionar categoria</InputLabel>
                 <Select
                   value={
-                    item["category"] || ""
+                    item.category?.name || ""
                   }
                   label="Categorías"
                   onChange={(e) =>
-                    setItem({ ...item, category: e.target.value })
+                    setItem({ ...item, category: {name: e.target.value} })
                   }
                   margin="normal"
       
@@ -159,7 +159,7 @@ export const TopicModals = ({
     
       // Este true del final es solo temporal hasta que exista el endpoint de editar tema.
       const editTopicModal = () => {
-        return innerActionTopicModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
+        return innerActionTopicModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", false) // AUX ELIMINAR ESTE BOOL!!!
       };
 
       return (

--- a/src/components/UI/Tables/Modals/topicModals.js
+++ b/src/components/UI/Tables/Modals/topicModals.js
@@ -49,7 +49,7 @@ export const TopicModals = ({
     });
 
     /////// Modals ///////   
-    const innerActionTopicModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, titleText, confirmButtonText, disableBcEndpointDoesNotExistYet=false) => {
+    const innerActionTopicModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, titleText, confirmButtonText) => {
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
             <DialogTitle
@@ -144,7 +144,7 @@ export const TopicModals = ({
                 <Button onClick={handleCloseModal} variant="outlined" color="error">
                   Cancelar
                 </Button>
-                <Button type="submit" disabled={disableBcEndpointDoesNotExistYet} variant="contained" color="primary">
+                <Button type="submit" variant="contained" color="primary">
                   {confirmButtonText}
                 </Button>
               </DialogActions>
@@ -159,7 +159,7 @@ export const TopicModals = ({
     
       // Este true del final es solo temporal hasta que exista el endpoint de editar tema.
       const editTopicModal = () => {
-        return innerActionTopicModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", false) // AUX ELIMINAR ESTE BOOL!!!
+        return innerActionTopicModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar");
       };
 
       return (

--- a/src/components/UI/Tables/Modals/topicModals.js
+++ b/src/components/UI/Tables/Modals/topicModals.js
@@ -48,7 +48,7 @@ export const TopicModals = ({
         setParentItem: setParentItem
     });
 
-    /////// Modals de Estudiante ///////   
+    /////// Modals ///////   
     const innerActionTopicModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, titleText, confirmButtonText, disableBcEndpointDoesNotExistYet=false) => {
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
@@ -80,7 +80,7 @@ export const TopicModals = ({
                   required
                   onChange={(e) => setItem({ ...item, name: e.target.value })}
                 />
-                <InputLabel>Seleccionar categoria</InputLabel>
+                <InputLabel>Seleccionar categoría</InputLabel>
                 <Select
                   value={
                     item.category?.name || ""
@@ -96,7 +96,7 @@ export const TopicModals = ({
                   fullWidth
                 >
                   <MenuItem key="" value="" disabled>
-                    Seleccionar categoria
+                    Seleccionar categoría
                   </MenuItem>
                   {categories.map((category) => (
                     <MenuItem key={category} value={category}>
@@ -110,7 +110,7 @@ export const TopicModals = ({
                   value={
                     item["tutor_email"] || ""
                   }
-                  label="Email del tutor"
+                  label="Email de tutor"
                   onChange={(e) =>
                     setItem({ ...item, tutor_email: e.target.value })
                   }

--- a/src/components/UI/Tables/Modals/tutorModals.js
+++ b/src/components/UI/Tables/Modals/tutorModals.js
@@ -41,7 +41,7 @@ export const TutorModals = ({
           setParentItem: setParentItem
       });
 
-      /////// Modals de Estudiante ///////      
+      /////// Modals ///////      
       const innerActionTutorModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -298,9 +298,9 @@ const ParentTable = ({
     });
   });
 
-  console.log("Items: ", items);
   if (loading) return <Typography variant="h6">Cargando...</Typography>;
-  const categories = title === TableType.TOPICS ? getCategories(items) : [];
+  const categories = title === TableType.TOPICS ? getCategories(data) : []; // debe ser sobre "data" y no otra variable.
+
   return (
     <>
       <Container maxWidth="lg">

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -180,7 +180,7 @@ const ParentTable = ({
     }
   };
 
-  const editItemInGenericTable = async (apiEditFunction, editedItem, setEditedItem, setReducer) => {
+  const editItemInGenericTable = async (apiEditFunction, editedItem, setEditedItem, setReducer) => {    
     const item = await apiEditFunction(originalEditedItemId, period.id, editedItem, user);
     setEditedItem({});
     setOriginalEditedItemId(null);
@@ -298,6 +298,7 @@ const ParentTable = ({
     });
   });
 
+  console.log("Items: ", items);
   if (loading) return <Typography variant="h6">Cargando...</Typography>;
   const categories = title === TableType.TOPICS ? getCategories(items) : [];
   return (


### PR DESCRIPTION
# Se completa nueva funcionalidad: Editar tema

En un PR anterior se había iniciado el modal y api call de esta nueva funcionalidad pero dejándo algunos botones deshabilitados porque aún no existía 100% en el back.
Este PR completa esa funcionalidad.

- **se elimina el bool que inhabilitaba clickear el botón** para abrir el modal cuando no existía el endpoint, **porque ya existe el endpoint** para editar tema.
- **minor fixes tildes**, ortografía, comentarios
- **se homogeiniza el formato de 'category' a usar y enviar al back**
- **fix a** obtención de categorías con **getCategory** (se debe usar "data" y no "filteredData" (que es lo que queda luego de buscar) ni "items" (que es lo del render inicial y puede estar desactualizado o vacío)).

---
- esto cierra el **issue** tpf-v2/assignment-service#22 :).