### PR TITLE
Cambios al front para que los CSV no dependan del ID de tutor

### DIFF
--- a/public/csvs/topics.csv
+++ b/public/csvs/topics.csv
@@ -1,10 +1,9 @@
-TEMA,CATEGORIA,TUTOR,CAPACIDAD
-Tema 1,Numero,tutor1@fi.uba.ar,1
-Tema 2,Numero,tutor2@fi.uba.ar,2
-Tema 3,Numero,tutor3@fi.uba.ar,3
-Tema A,Letra,tutor1@fi.uba.ar,1
-Tema B,Letra,tutor2@fi.uba.ar,2
-Tema C,Letra,tutor3@fi.uba.ar,3
-Tema Facil,Palabra,tutor1@fi.uba.ar,1
-Tema Medio,Palabra,tutor2@fi.uba.ar,2
-Tema Dificil,Palabra,tutor3@fi.uba.ar,3
+TEMA,CATEGORIA,TUTOR_MAIL,CAPACIDAD
+Blockchain & NFT,Inteligencia Artificial y temas afines,hmerlino@fi.uba.ar,1
+Trading Algorítmico,Inteligencia Artificial y temas afines,hmerlino@fi.uba.ar,1
+Birrómetro: Hidrómetro digital para la elaboración de cerveza,default,jcabrera@fi.uba.ar,1
+PyLab,default,aservetto@fi.uba.ar,1
+Sistema de Apoyo a Cultivos Hidropónicos,default,jcabrera@fi.uba.ar,1
+Aplicación para cultivos hidropónicos,default,jcabrera@fi.uba.ar,1
+Simulación para Arquitecturas RISC,default,aservetto@fi.uba.ar,1
+Mímir: Sistema de monitoreo para cultivos hidropónicos,default,jcabrera@fi.uba.ar,1

--- a/public/csvs/tutors.csv
+++ b/public/csvs/tutors.csv
@@ -1,4 +1,33 @@
-NOMBRE,APELLIDO,DNI,MAIL,CAPACIDAD
-Tutor,Prueba 1,10000001,tutor1@fi.uba.ar,4
-Tutor,Prueba 2,10000002,tutor2@fi.uba.ar,4
-Tutor,Prueba 3,10000003,tutor3@fi.uba.ar,4
+NOMBRE,APELLIDO,MAIL,CAPACIDAD
+Ariel,Scarpinelli,ascarpinelli@fi.uba.ar,1
+Arturo,Servetto,aservetto@fi.uba.ar,3
+Damián,Martinelli,damianmarti@gmail.com,2
+Facundo,Caram,fcaram@fi.uba.ar,1
+Maia,Naftali,mnaftali@fi.uba.ar,2
+Silvia,Ramos,silviaadrianaramos@gmail.com,1
+Mariano,Méndez,marianomendez@fi.uba.ar,8
+Alejandro,Molinari,amolinari@fi.uba.ar,4
+Bruno,Lanzillotta,blanzillotta@fi.uba.ar,3
+Diego,García Jaime,dgarciajaime@fi.uba.ar,3
+Gabriel,Piñeiro,gpineiro@fi.uba.ar,5
+Gustavo,Carolo,gustavocarolo@gmail.com,2
+Jorge,Ierache,jierache@fi.uba.ar,4
+José Luis,Cabrera,jcabrera@fi.uba.ar,3
+Marcos,Saladino,msaladino@fi.uba.ar,3
+Diego,Montaldo,dmontal@fi.uba.ar,1
+Nicolás,Páez,npaez@fi.uba.ar,1
+Cesar,Caiafa,ccaiafa@fi.uba.ar,2
+Carlos,Fontela,cfontela@fi.uba.ar,1
+Pablo,Deymonaz,pdeymon@fi.uba.ar,1
+Hernan,Merlino,hmerlino@fi.uba.ar,2
+Agustín,Perrotta,aperrotta@fi.uba.ar,2
+Fernando,Chaure,fchaure@fi.uba.ar,2
+Maria Alejandra,Ochoa,maochoa@fi.uba.ar,3
+María Mercedes,Madeira,mmadeira@fi.uba.ar,4
+Mauro,Ciancio,mauro.ciancio@gmail.com,3
+Pablo,Cosso,pcosso@fi.uba.ar,3
+Edgardo,Marchi,emarchi@fi.uba.ar,2
+Martin,Buchwald,mbuchwald@fi.uba.ar,3
+Emmanuel Eduardo,Espina,eespina@fi.uba.ar,2
+Alejandro,Turri,alejandroturri20@gmail.com,1
+María Pilar,Gaddi,mgaddi@fi.uba.ar,1

--- a/src/components/Forms/UploadCSVForm.js
+++ b/src/components/Forms/UploadCSVForm.js
@@ -119,12 +119,16 @@ const UploadCSVForm = ({ formType, setItems }) => {
         setIsSuccess(false);
       }
     } catch (error) {
+      let errorMessage = "Error al cargar el archivo de ${TITLE_DICT[formType]}";
+      if (error.response && error.response.data && error.response.data.detail) {
+        errorMessage = error.response.data.detail;
+      }
       console.error(
-        `Error al cargar el archivo de ${TITLE_DICT[formType]}`,
+        errorMessage,
         error
       );
       setResponseMessage(
-        `Error al cargar el archivo de ${TITLE_DICT[formType]}`
+        errorMessage
       );
       setIsSuccess(false);
     } finally {

--- a/src/components/UI/Tables/ChildTables/TopicsTable.js
+++ b/src/components/UI/Tables/ChildTables/TopicsTable.js
@@ -28,9 +28,10 @@ const TopicsTable = () => {
     </>
   );
 
+  const customCsvUri = `/topics/topics.csv?period_id=${period.id}`;
 
   return (
-    <ParentTable title={title} columns={columns} rowKeys={rowKeys} endpoint={endpoint} renderRow={renderRow} items={topics} enableEdit={true}/>
+    <ParentTable title={title} columns={columns} rowKeys={rowKeys} endpoint={endpoint} renderRow={renderRow} items={topics} enableEdit={true} customCsvUri={customCsvUri}/>
   );
 };
 

--- a/src/components/UI/Tables/ChildTables/TutorsTable.js
+++ b/src/components/UI/Tables/ChildTables/TutorsTable.js
@@ -33,8 +33,10 @@ const TutorsTable = () => {
     </>
   );
 
+  const customCsvUri = `/tutors/tutors.csv?period_id=${period}`;
+
   return (
-    <ParentTable title={title} columns={columns} rowKeys={rowKeys} endpoint={endpoint} renderRow={renderRow} items={tutors}/>
+    <ParentTable title={title} columns={columns} rowKeys={rowKeys} endpoint={endpoint} renderRow={renderRow} items={tutors} customCsvUri={customCsvUri}/>
   );
 };
 

--- a/src/services/validateUrl.js
+++ b/src/services/validateUrl.js
@@ -1,0 +1,12 @@
+export default async function validateUrl(url) {
+    try {
+        const response = await fetch(url, {method: 'OPTIONS'});
+        if (response === 405) {
+            return false;
+        } else {
+            return true;
+        }
+    } catch (error) {
+        return false;
+    }
+}


### PR DESCRIPTION

- Actualizados CSVs de ejemplo ya que cambiaron
- Hacer que en la importacion de CSV se muestre el mensaje de error devuelto por el API
- Usar un endpoint dedicado del backend para generar el CSV, en lugar de solo generarlo desde el front. Esto por el momento solo aplica a topics.csv y tutors.csv