### PR TITLE
Feat/editar equipo

### DIFF
--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -50,16 +50,10 @@ export const editTeam = async (groupId, periodId, teamToEdit, user, confirm_move
   const intStudentIds = studentsInput
   .map(s => s.id)
   .filter(id => Number.isInteger(id));
-  
-  console.log("int:", intStudentIds);
-  console.log("input:", studentsInput);
-  // if (intStudentIds.length !== studentsInput.length){
-  //   return; // <--- nop, esto sale sin informar error.
-  // };
 
   const sendableTeamToEdit = {
     "students_ids": intStudentIds,
-    "tutor_email": teamToEdit.tutor_email, //getTutorEmailByTutorPeriodId(groupToEdit.tutor_period_id, periodId),
+    "tutor_email": teamToEdit.tutor_email,
     "topic_id": teamToEdit.topic.id,
     "confirm_move": confirm_move,
   };  
@@ -70,7 +64,6 @@ export const editTeam = async (groupId, periodId, teamToEdit, user, confirm_move
       return response.data;
   } catch (err) {
       console.error(`Error when editing team: ${err}`)
-      //throw new Error(err);
       throw err;
   }
 };

--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -35,7 +35,7 @@ export const sendGroupForm = async (period, payload, existingGroup, user) => {
   }
 };
 
-export const editGroup = async (groupId, periodId, groupToEdit, user, confirm_move_student=false) => {
+export const editGroup = async (groupId, periodId, groupToEdit, user, confirm_move=false) => {
   const config = {
       headers: {
         Authorization: `Bearer ${user.token}`,
@@ -61,7 +61,7 @@ export const editGroup = async (groupId, periodId, groupToEdit, user, confirm_mo
     "students_ids": intStudentIds,
     "tutor_email": groupToEdit.tutor_email, //getTutorEmailByTutorPeriodId(groupToEdit.tutor_period_id, periodId),
     "topic_id": groupToEdit.topic.id,
-    "confirm_move_student": confirm_move_student,
+    "confirm_move": confirm_move,
   };
   
   try {
@@ -69,7 +69,7 @@ export const editGroup = async (groupId, periodId, groupToEdit, user, confirm_mo
       const response = await axios.patch(url, sendableGroupToEdit, config);
       return response.data;
   } catch (err) {
-      console.error(`Error when editing group: ${err}`)
+      console.error(`Error when editing team: ${err}`)
       //throw new Error(err);
       throw err;
   }

--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -34,3 +34,29 @@ export const sendGroupForm = async (period, payload, existingGroup, user) => {
     return error.response
   }
 };
+
+export const editGroup = async (groupId, periodId, groupToEdit, user) => {
+  const config = {
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+      },
+    };
+
+
+  // Con esto enviamos Exactamente los campos que el back espera (y excluimos el id, que ya está
+  // como path param)
+  const sendableGroupToEdit = {
+    "students_ids": [groupToEdit.student_id_1, groupToEdit.student_id_2, groupToEdit.student_id_3, groupToEdit.student_id_4],
+    "tutor_email": groupToEdit.tutor_email,
+    "topic_id": groupToEdit.topic_id,
+  };
+  
+  try {
+      const url = `${BASE_URL}/groups/${groupId}/periods/${periodId}`;
+      const response = await axios.patch(url, sendableGroupToEdit, config);
+      return response.data;
+  } catch (err) {
+      console.error(`Error when editing group: ${err}`)
+      throw new Error(err);
+  }
+};

--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -45,10 +45,22 @@ export const editGroup = async (groupId, periodId, groupToEdit, user) => {
 
   // Con esto enviamos Exactamente los campos que el back espera (y excluimos el id, que ya está
   // como path param)
+  const studentsInput = groupToEdit.students;
+  
+  const intStudentIds = studentsInput
+  .map(s => s.id)
+  .filter(id => Number.isInteger(id));
+  
+  console.log("int:", intStudentIds);
+  console.log("input:", studentsInput);
+  // if (intStudentIds.length !== studentsInput.length){
+  //   return; // <--- nop, esto sale sin informar error.
+  // };
+
   const sendableGroupToEdit = {
-    "students_ids": [groupToEdit.student_id_1, groupToEdit.student_id_2, groupToEdit.student_id_3, groupToEdit.student_id_4],
+    "students_ids": intStudentIds,
     "tutor_email": groupToEdit.tutor_email,
-    "topic_id": groupToEdit.topic_id,
+    "topic_id": groupToEdit.topic.id,
   };
   
   try {

--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -35,16 +35,6 @@ export const sendGroupForm = async (period, payload, existingGroup, user) => {
   }
 };
 
-// const getTutorEmailByTutorPeriodId = (id, periodId) => {
-//   const tutor = tutors.find(
-//   (t) =>
-//       t.tutor_periods &&
-//       t.tutor_periods.some((tp) => tp.period_id === periodId && tp.id === id)
-//   );
-//   return tutor ? tutor.email : "Sin asignar"; // Si no encuentra el tutor, mostrar 'Sin asignar'
-// };  
-//getTutorEmailByTutorPeriodId(groupToEdit.tutor_period_id, periodId),
-
 export const editGroup = async (groupId, periodId, groupToEdit, user) => {
   const config = {
       headers: {

--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -35,6 +35,16 @@ export const sendGroupForm = async (period, payload, existingGroup, user) => {
   }
 };
 
+// const getTutorEmailByTutorPeriodId = (id, periodId) => {
+//   const tutor = tutors.find(
+//   (t) =>
+//       t.tutor_periods &&
+//       t.tutor_periods.some((tp) => tp.period_id === periodId && tp.id === id)
+//   );
+//   return tutor ? tutor.email : "Sin asignar"; // Si no encuentra el tutor, mostrar 'Sin asignar'
+// };  
+//getTutorEmailByTutorPeriodId(groupToEdit.tutor_period_id, periodId),
+
 export const editGroup = async (groupId, periodId, groupToEdit, user) => {
   const config = {
       headers: {
@@ -59,7 +69,7 @@ export const editGroup = async (groupId, periodId, groupToEdit, user) => {
 
   const sendableGroupToEdit = {
     "students_ids": intStudentIds,
-    "tutor_email": groupToEdit.tutor_email,
+    "tutor_email": groupToEdit.tutor_email, //getTutorEmailByTutorPeriodId(groupToEdit.tutor_period_id, periodId),
     "topic_id": groupToEdit.topic.id,
   };
   

--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -35,7 +35,7 @@ export const sendGroupForm = async (period, payload, existingGroup, user) => {
   }
 };
 
-export const editGroup = async (groupId, periodId, groupToEdit, user, confirm_move=false) => {
+export const editTeam = async (groupId, periodId, teamToEdit, user, confirm_move=false) => {
   const config = {
       headers: {
         Authorization: `Bearer ${user.token}`,
@@ -45,7 +45,7 @@ export const editGroup = async (groupId, periodId, groupToEdit, user, confirm_mo
 
   // Con esto enviamos Exactamente los campos que el back espera (y excluimos el id, que ya está
   // como path param)
-  const studentsInput = groupToEdit.students;
+  const studentsInput = teamToEdit.students;
   
   const intStudentIds = studentsInput
   .map(s => s.id)
@@ -57,16 +57,16 @@ export const editGroup = async (groupId, periodId, groupToEdit, user, confirm_mo
   //   return; // <--- nop, esto sale sin informar error.
   // };
 
-  const sendableGroupToEdit = {
+  const sendableTeamToEdit = {
     "students_ids": intStudentIds,
-    "tutor_email": groupToEdit.tutor_email, //getTutorEmailByTutorPeriodId(groupToEdit.tutor_period_id, periodId),
-    "topic_id": groupToEdit.topic.id,
+    "tutor_email": teamToEdit.tutor_email, //getTutorEmailByTutorPeriodId(groupToEdit.tutor_period_id, periodId),
+    "topic_id": teamToEdit.topic.id,
     "confirm_move": confirm_move,
-  };
-  
+  };  
+
   try {
       const url = `${BASE_URL}/groups/${groupId}/periods/${periodId}`;
-      const response = await axios.patch(url, sendableGroupToEdit, config);
+      const response = await axios.patch(url, sendableTeamToEdit, config);
       return response.data;
   } catch (err) {
       console.error(`Error when editing team: ${err}`)

--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -35,7 +35,7 @@ export const sendGroupForm = async (period, payload, existingGroup, user) => {
   }
 };
 
-export const editGroup = async (groupId, periodId, groupToEdit, user) => {
+export const editGroup = async (groupId, periodId, groupToEdit, user, confirm_move_student=false) => {
   const config = {
       headers: {
         Authorization: `Bearer ${user.token}`,
@@ -61,6 +61,7 @@ export const editGroup = async (groupId, periodId, groupToEdit, user) => {
     "students_ids": intStudentIds,
     "tutor_email": groupToEdit.tutor_email, //getTutorEmailByTutorPeriodId(groupToEdit.tutor_period_id, periodId),
     "topic_id": groupToEdit.topic.id,
+    "confirm_move_student": confirm_move_student,
   };
   
   try {
@@ -69,6 +70,7 @@ export const editGroup = async (groupId, periodId, groupToEdit, user) => {
       return response.data;
   } catch (err) {
       console.error(`Error when editing group: ${err}`)
-      throw new Error(err);
+      //throw new Error(err);
+      throw err;
   }
 };

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -61,7 +61,6 @@ const GroupDataTable = () => {
   const [conflictsMessage, setConflictsMessage] = useState([]);
   // Editar equipo
   const [openEditModal, setOpenEditModal] = useState(false);
-  const [originalEditedItemId, setOriginalEditedItemId] = useState(null);
   const [itemToPassToModal, setItemToPassToModal] = useState(null);
   
   const dispatch = useDispatch();
@@ -100,8 +99,7 @@ const GroupDataTable = () => {
       await editItemInGenericTable(editTeam, editedItem, setEditedItem, setGroups, confirm_option);
       
       // Close modal de edición en caso de éxito
-      handleCloseEditModal();
-      setOriginalEditedItemId(null); // AUX: Agrego esto acá.
+      handleCloseEditModal();      
       setEditedItem({}); // necesario para el segundo modal, el de confirm.      
     } catch (err) {
       const title="team";
@@ -513,11 +511,9 @@ const GroupDataTable = () => {
 
           <TeamModal 
             openEditModal={openEditModal}
-            setOpenEditModal={setOpenEditModal}
-            
+            setOpenEditModal={setOpenEditModal}            
             handleEditItem={handleEditItem}
-            originalEditedItemId={originalEditedItemId}
-            setOriginalEditedItemId={setOriginalEditedItemId}
+            
             item={itemToPassToModal}
             setParentItem={setItemToPassToModal}
 

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -21,6 +21,7 @@ import ExpandableCell from "../ExpandableCell";
 import { TeamModal } from "../UI/Tables/Modals/teamModal";
 import { setGroups } from "../../redux/slices/groupsSlice";
 import { editGroup } from "../../api/sendGroupForm";
+import MySnackbar from "../UI/MySnackBar";
 
 // Componente para la tabla de equipos
 const GroupDataTable = () => {
@@ -60,10 +61,10 @@ const GroupDataTable = () => {
       await editItemInGenericTable(editGroup, editedItem, setEditedItem, setGroups);
     } catch (err) {
       const title="groups";
-      console.error(`Error when editing new ${title}:`, err);
+      console.error(`Error when editing ${title}:`, err);
       setNotification({
         open: true,
-        message: `Error al editar Equipo||''}.`,
+        message: `Error al editar Equipo.`,
         status: "error",
       });
     } finally {
@@ -91,6 +92,9 @@ const GroupDataTable = () => {
     message: "",
     status: "",
   });
+  const handleSnackbarClose = () => {
+    setNotification({ ...notification, open: false });
+  };
   //////////////////// fin lo necesario para edit ///////
 
   useEffect(() => {
@@ -214,6 +218,8 @@ const GroupDataTable = () => {
   const [showExtraColumns, setShowExtraColumns] = useState(false);
 
   console.log("--- filteredGroups:", filteredGroups);
+  console.log("--- tutoressss:", tutors);
+
   return (
     <Box>
       {loading ? (
@@ -407,6 +413,12 @@ const GroupDataTable = () => {
             topics={topics}
             tutors={tutors}
           />  
+          <MySnackbar
+            open={notification.open}
+            handleClose={handleSnackbarClose}
+            message={notification.message}
+            status={notification.status}
+          />
         </>
 
 

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -186,26 +186,19 @@ const GroupDataTable = () => {
             >
               <TableHead>
                 <TableRow>
-                  <TableCell sx={{ fontWeight: "bold" }}>
-                    Equipo número
-                  </TableCell>
+                  <TableCell sx={{ fontWeight: "bold" }}>Equipo número</TableCell>
+
+                  <TableCell sx={{ fontWeight: "bold" }}>Padrón</TableCell>
                   <TableCell sx={{ fontWeight: "bold" }}>Nombre</TableCell>
                   <TableCell sx={{ fontWeight: "bold" }}>Apellido</TableCell>
                   <TableCell sx={{ fontWeight: "bold" }}>Email</TableCell>
-                  <TableCell sx={{ fontWeight: "bold" }}>Padrón</TableCell>
+
                   <TableCell sx={{ fontWeight: "bold" }}>Tutor</TableCell>
-                  <TableCell sx={{ fontWeight: "bold" }}>
-                    Tema asignado
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: "bold" }}>
-                    Preferencia 1
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: "bold" }}>
-                    Preferencia 2
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: "bold" }}>
-                    Preferencia 3
-                  </TableCell>
+                  <TableCell sx={{ fontWeight: "bold" }}>Tema asignado</TableCell>
+
+                  <TableCell sx={{ fontWeight: "bold" }}>Preferencia 1</TableCell>
+                  <TableCell sx={{ fontWeight: "bold" }}>Preferencia 2</TableCell>
+                  <TableCell sx={{ fontWeight: "bold" }}>Preferencia 3</TableCell>
                 </TableRow>
               </TableHead>
 
@@ -215,6 +208,7 @@ const GroupDataTable = () => {
                     <TableRow sx={{ backgroundColor: "#f0f0f0" }}>
                       <TableCell colSpan={10} align="center"></TableCell>
                     </TableRow>
+                    {/* Table content */}
                     <TableCell
                       rowSpan={group.students?.length + 1}
                       align="center"
@@ -223,10 +217,10 @@ const GroupDataTable = () => {
                     </TableCell>
                     {group.students.map((student, index) => (
                       <TableRow key={student.id}>
+                        <TableCell>{student.id}</TableCell>
                         <TableCell>{student.name}</TableCell>
                         <TableCell>{student.last_name}</TableCell>
                         <TableCell>{student.email}</TableCell>
-                        <TableCell>{student.id}</TableCell>
                         <>
                           {index === 0 && (
                             <TableCell

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -9,7 +9,6 @@ import {
   TableRow,
   TextField,
   Button,
-  Collapse,
   Box,
   Stack
 } from "@mui/material";
@@ -52,6 +51,7 @@ const GroupDataTable = () => {
   ////////// Inicio lo necesario para editar equipo, Revisar []
   const user = useSelector((state) => state.user);
   const [openConfirmEditModal, setOpenConfirmEditModal] = useState(false); // [] aux: los voy a pasar en el lugar del add, VOLVER
+  const [conflictsMessage, setConflictsMessage] = useState([]);
   // Editar equipo
   const [openEditModal, setOpenEditModal] = useState(false);
   const [originalEditedItemId, setOriginalEditedItemId] = useState(null);
@@ -70,31 +70,28 @@ const GroupDataTable = () => {
       setOriginalEditedItemId(null); // AUX: Agrego esto acá.
       setEditedItem({}); /////
     } catch (err) {
-      const title="groups";
+      const title="team";
       console.error(`Error when editing ${title}:`, err);
       setNotification({
         open: true,
         message: `Error al editar equipo.`,
         status: "error",
       });
-      console.log("--- CONFLICTO, VOY A ABRIR EL MODAL DE CONFIRMACIÓN ACTUALMENTE CERRADO". openConfirmEditModal);
+      console.log("--- CONFLICTO, VOY A ABRIR EL MODAL DE CONFIRMACIÓN ACTUALMENTE CERRADO", openConfirmEditModal);
 
-      // Probando, hay que abrir otro modal o alert para mostrar el msj (que no me acuerdo si devolví desde el back)
-      // y pedirle confirmación (entonces mandar el confirm en true) o cancelar y no hacer nada.
-      // Si hay conflicto, no cerrar el modal de edición. Abrir cartel de confirmación y si se cancela
+      // Si hay conflicto, no cerrar el modal de edición; abrir cartel de confirmación
+      // y si se confirma, se reenvía la request (conservar los datos a enviar) pero con un bool en true
       if (err.response?.status===409) {
         setNotification({
           open: true,
-          message: `Error al editar equipo: fue conflicccccttttt!.`,
-          status: "error",
+          message: `Advertencia: Conflicto al editar equipo.`,
+          status: "warning",
         });
+        //console.log("conflict:", err.response.data.detail);
 
+        setConflictsMessage(err.response?.data?.detail || []);
         setOpenConfirmEditModal(true);
-        console.log("--- HE ABIERTO EL MODAL DE CONFIRMACIÓN". openConfirmEditModal);
-        
       }
-    } finally {
-      
     }
   };
   const editItemInGenericTable = async (apiEditFunction, editedItem, setEditedItem, setReducer, confirm_option=false) => {    
@@ -130,7 +127,6 @@ const GroupDataTable = () => {
       console.log("--- CONFIRMAR API CALL ERRÓNEA:", err);
     }
   };
-  console.log("--- HOLA ----- MODAL DE CONFIRMACIÓN, abierto?:". openConfirmEditModal);
   //////
   // Formato
   const getTutorEmailByTutorPeriodId = (id, periodId) => {
@@ -262,9 +258,6 @@ const GroupDataTable = () => {
   };
 
   const [showExtraColumns, setShowExtraColumns] = useState(false);
-
-  console.log("--- filteredGroups:", filteredGroups);
-  console.log("--- tutoressss:", tutors);
 
   return (
     <Box>
@@ -469,6 +462,9 @@ const GroupDataTable = () => {
             openAddModal={openConfirmEditModal}
             setOpenAddModal={setOpenConfirmEditModal}
             handleAddItem={handleConfirmEditOnConflict}
+
+            conflictMsg={conflictsMessage}
+            setConflictMsg={setConflictsMessage}
 
             topics={topics}
             tutors={tutors}

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -65,7 +65,7 @@ const GroupDataTable = () => {
       console.error(`Error when editing ${title}:`, err);
       setNotification({
         open: true,
-        message: `Error al editar Equipo.`,
+        message: `Error al editar equipo.`,
         status: "error",
       });
     } finally {
@@ -78,7 +78,7 @@ const GroupDataTable = () => {
     setOriginalEditedItemId(null);
     setNotification({
       open: true,
-      message: `Se editó Equipo exitosamente`,
+      message: `Se editó equipo exitosamente`,
       status: "success",
     });
     setData((prevData) =>

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -14,7 +14,6 @@ import {
 } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-//import { Box } from "@mui/system";
 import ExpandableCell from "../ExpandableCell";
 
 import { TeamModal } from "../UI/Tables/Modals/teamModal";
@@ -84,7 +83,7 @@ const GroupDataTable = () => {
         setLoading(false);
 
       } catch (error) {
-        console.error("Error fetching data:", error);
+        console.error("Error fetching teams data:", error);
         setLoading(false); // Handle error
       }
     };
@@ -112,7 +111,6 @@ const GroupDataTable = () => {
         message: `Error al editar equipo.`,
         status: "error",
       });
-      console.log("--- CONFLICTO, VOY A ABRIR EL MODAL DE CONFIRMACIÓN ACTUALMENTE CERRADO", openConfirmEditModal);
 
       // Si hay conflicto, no cerrar el modal de edición; abrir cartel de confirmación
       // y si se confirma, se reenvía la request (conservar los datos a enviar) pero con un bool en true
@@ -146,7 +144,7 @@ const GroupDataTable = () => {
           // reemplazo si ya existía
           updated[idx] = team;
         } else {
-          // o agrego si no estaba en la lista
+          // o agrego si no estaba en la lista [aux: por qué no estaría en la lista si es un edit y no un add?]
           updated.push(team);
         }
       });
@@ -169,13 +167,7 @@ const GroupDataTable = () => {
   /////
   // Confirmar edición con bool true
   const handleConfirmEditOnConflict = async (editedItem, setEditedItem, handleCloseEditModal, confirm_option=true) => {
-    try {
-      console.log("--- CONFIRMAR API CALL A PUNTO DE HACERSE");
-      await handleEditItem(editedItem, setEditedItem, handleCloseEditModal, true);
-      console.log("--- CONFIRMAR API CALL HECHA");
-    } catch(err) {
-      console.log("--- CONFIRMAR API CALL ERRÓNEA:", err);
-    }
+    await handleEditItem(editedItem, setEditedItem, handleCloseEditModal, true);
   };
   //////
   // Formato
@@ -235,7 +227,7 @@ const GroupDataTable = () => {
     console.log("--- teams:", teams);
     return showNoTutor ? teams.filter((team) => !team.tutor_period_id) : teams
   };
-  // Filtrar equipos según el término de búsqueda Contemplando si se clickeó el botón de showNoTopics
+  // Filtrar equipos según el término de búsqueda
   const filteredTeamsBySearchTerm = data.filter(
     (team) =>
       team?.students?.some(
@@ -254,7 +246,7 @@ const GroupDataTable = () => {
         .toLowerCase()
         .includes(searchTerm.toLowerCase())
   );
-  // Obtengo solo los que no tienen topic y/o tutor, o bien conservo lo que ya tenía, según el bool
+  // Contemplo si se clickeó botones de showNoX: obtengo solo los que no tienen topic y/o tutor, o bien conservo lo que ya tenía, según el bool
   const filteredTeams = showTeamsWithNoTopic(showTeamsWithNoTutor(filteredTeamsBySearchTerm));
   console.log("filteredTeams:", filteredTeams);
   // Función para descargar los datos en formato CSV
@@ -489,7 +481,7 @@ const GroupDataTable = () => {
                           )                            
                           )}
                         
-                        {/* Copypasteo desde ParentTable esta sección de los botones, ver [] */}
+                        {/* Sección de los botones */}
                         {index === 0 && (
                           <TableCell rowSpan={team.students.length}>
                             <Stack direction="row" spacing={1}>                          

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -44,7 +44,11 @@ const GroupDataTable = () => {
   .map(({ version, rehydrated, ...rest }) => rest)
   .filter(item => Object.keys(item).length > 0);
 
+  const [showExtraColumns, setShowExtraColumns] = useState(false);
+
   const [searchTerm, setSearchTerm] = useState("");
+  const [showNoTopic, setShowNoTopic] = useState(false);
+  const [showNoTutor, setShowNoTutor] = useState(false);
 
   const [loading, setLoading] = useState(true);
 
@@ -172,8 +176,24 @@ const GroupDataTable = () => {
     return tutor ? tutor.name + " " + tutor.last_name : "Sin asignar"; // Si no encuentra el tutor, mostrar 'Sin asignar'
   };
 
-  // Filtrar equipos según el término de búsqueda
-  const filteredGroups = groups.filter(
+  ///// Opciones de búsqueda y filtrado /////
+  const handleShowTeamsWithNoTopic = () => {
+    setShowNoTopic(prev => !prev)
+  };
+
+  const handleShowTeamsWithNoTutor = () => {
+    setShowNoTutor(prev => !prev)
+  };
+  
+  const showTeamsWithNoTopic = (teams) => {
+    return showNoTopic ? teams.filter((team) => !team.topic) : teams
+  };
+  const showTeamsWithNoTutor = (teams) => {
+    console.log("--- teams:", teams);
+    return showNoTutor ? teams.filter((team) => !team.tutor_period_id) : teams
+  };
+  // Filtrar equipos según el término de búsqueda Contemplando si se clickeó el botón de showNoTopics
+  const filteredTeamsBySearchTerm = groups.filter(
     (group) =>
       group.students.some(
         (student) =>
@@ -191,7 +211,9 @@ const GroupDataTable = () => {
         .toLowerCase()
         .includes(searchTerm.toLowerCase())
   );
-
+  // Obtengo solo los que no tienen topic y/o tutor, o bien conservo lo que ya tenía, según el bool
+  const filteredGroups = showTeamsWithNoTopic(showTeamsWithNoTutor(filteredTeamsBySearchTerm));
+  
   // Función para descargar los datos en formato CSV
   const downloadCSV = () => {
     const csvRows = [];
@@ -208,7 +230,7 @@ const GroupDataTable = () => {
         "Preferencia 2",
         "Preferencia 3",
       ].join(",")
-    );
+    );    
 
     filteredGroups.forEach((group) => {
       group.students.forEach((student, index) => {
@@ -257,8 +279,6 @@ const GroupDataTable = () => {
     URL.revokeObjectURL(url);
   };
 
-  const [showExtraColumns, setShowExtraColumns] = useState(false);
-
   return (
     <Box>
       {loading ? (
@@ -292,8 +312,27 @@ const GroupDataTable = () => {
               Descargar CSV
             </Button>
 
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={handleShowTeamsWithNoTopic}
+              sx={{ marginBottom: 2 }}
+            >
+              {showNoTopic ? "Mostrar todos los equipos" : "Mostrar equipos sin tema"}
+            </Button>
+
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={handleShowTeamsWithNoTutor}
+              sx={{ marginBottom: 2 }}
+            >
+              {showNoTutor ? "Mostrar todos los equipos" : "Mostrar equipos sin tutor"}
+            </Button>
+
             <Button variant="outlined" color="primary" 
-              onClick={() => setShowExtraColumns(prev => !prev)}>
+              onClick={() => setShowExtraColumns(prev => !prev)}
+              sx={{ marginBottom: 2 }}>
               {showExtraColumns ? "Ocultar preferencias" : "Mostrar preferencias"}
             </Button>
           </Box>

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -46,17 +46,7 @@ const GroupDataTable = () => {
   .filter(item => Object.keys(item).length > 0);
 
   const [allTopics, setAllTopics] = useState({csvTopics: topics, customTopics: []});
-  //const [customTopics, setCustomTopics] = useState();
-  // const addCustomTopicsToAllTopics = () => {
-  //   // Workaround a que el back no los devuelva
-  //   // agrego los temas de quienes pusieron "Ya tengo tema y tutor"
-  //   const customTopics = groups.filter(team => !topics.some(t => t.id === team.topic.id))
-  //   .map(team => team.topic);
-  //   console.log("### Custom topics:", customTopics);
-  //   setAllTopics((prevData) => [...prevData, ...customTopics]);
-  // }  
-  
-  //const constAllTopics = topics.concat(customTopics);
+  const [data, setData] = useState(groups);
 
   const [showExtraColumns, setShowExtraColumns] = useState(false);
 
@@ -75,10 +65,9 @@ const GroupDataTable = () => {
   const [originalEditedItemId, setOriginalEditedItemId] = useState(null);
   const [itemToPassToModal, setItemToPassToModal] = useState(null);
   
-  const [data, setData] = useState(groups);
   const dispatch = useDispatch();
 
-  /// Los useEffect los pongo acá
+  /// useEffect
   const endpoint = `/groups/?period=${period.id}`;
 
   useEffect(() => {
@@ -89,13 +78,11 @@ const GroupDataTable = () => {
         // Workaround a que el back no los devuelva: temas de "Ya tengo tema y tutor":
         const customTopics = groups.filter(team => !topics.some(t => t.id === team.topic.id))
         .map(team => team.topic);
-        console.log("### Custom topics:", customTopics);
         setAllTopics({csvTopics: topics, customTopics: customTopics});
         
-        console.log("Response data:", responseData);
         setData(responseData);
-        
         setLoading(false);
+
       } catch (error) {
         console.error("Error fetching data:", error);
         setLoading(false); // Handle error
@@ -105,39 +92,18 @@ const GroupDataTable = () => {
     fetchData();
   }, [endpoint, user]);
   //}, [endpoint, user, groups, topics]);
-
-  // useEffect(() => {
-  //   // if (groups.length > 0) {
-  //   //   setLoading(false);      
-  //   // }
-  //   if (data.length > 0) {
-  //     setLoading(false);      
-  //   }
-  // }, [data]);
-
-  // useEffect(() => {
-  //   // Configurar un temporizador de 3 segundos
-  //   const timer = setTimeout(() => {
-  //     setLoading(false);
-  //   }, 3000);
-
-  //   // Limpiar el temporizador si el componente se desmonta
-  //   return () => clearTimeout(timer);
-  // }, []);
   /// fin useEffect
+
   // Aux: Editar equipo, la traigo copypaste, veré de refactorizar para reutilizar después []
   const handleEditItem = async (editedItem, setEditedItem, handleCloseEditModal, confirm_option=false) => {
     try {
-      console.log("#### DESDE AFUERA, item completo:", editedItem);
-      console.log("   - desde afuera tmb, topic:", editedItem.topic.id);
-      console.log("   - y desde afuera tmb, get name da:", getTopicNameById(editedItem.topic.id));
       editedItem.tutor_email = getTutorEmailByTutorPeriodId(editedItem.tutor_period_id, period.id);
       await editItemInGenericTable(editGroup, editedItem, setEditedItem, setGroups, confirm_option);
       
       // Close modal de edición en caso de éxito
       handleCloseEditModal();
       setOriginalEditedItemId(null); // AUX: Agrego esto acá.
-      setEditedItem({}); ///// para el segundo modal, el de confirm.
+      setEditedItem({}); // necesario para el segundo modal, el de confirm.
     } catch (err) {
       const title="team";
       console.error(`Error when editing ${title}:`, err);
@@ -156,7 +122,6 @@ const GroupDataTable = () => {
           message: `Advertencia: Conflicto al editar equipo.`,
           status: "warning",
         });
-        //console.log("conflict:", err.response.data.detail);
 
         setConflictsMessage(err.response?.data?.detail || []);
         setOpenConfirmEditModal(true);
@@ -341,15 +306,10 @@ const GroupDataTable = () => {
     URL.revokeObjectURL(url);
   };
 
-  console.log("--- Desde afuera, allTopics:", allTopics);
+  console.log("allTopics:", allTopics);
 
   return (
-    <Box>
-      {loading ? (
-            <Box display="flex" justifyContent="center" alignItems="center">
-              <CircularProgress />
-            </Box>
-      ) : (
+    <Box>      
         <>
           <TextField
             label="Buscar"
@@ -561,7 +521,6 @@ const GroupDataTable = () => {
             setConflictMsg={setConflictsMessage}
 
             topics={allTopics}
-            //topics={constAllTopics}            
             tutors={tutors}
             students={students}
             periodId={period.id}
@@ -573,8 +532,6 @@ const GroupDataTable = () => {
             status={notification.status}
           />
         </>
-      )}
-
     </Box>
   )
 };

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -363,14 +363,7 @@ const GroupDataTable = () => {
                   </ExpandableCell>
                   <ExpandableCell show={showExtraColumns} isHeader>
                       Preferencia 3
-                  </ExpandableCell>
-                  
-
-                  {/*<TableCell sx={{ fontWeight: "bold" }}>
-                    <Button onClick={() => setShowExtraColumns(prev => !prev)}>
-                      {showExtraColumns ? "Ocultar preferencias" : "Mostrar preferencias"}
-                    </Button>
-                  </TableCell>*/}
+                  </ExpandableCell>                  
                   
                   <TableCell sx={{ fontWeight: "bold" }}>Acciones</TableCell>
                   
@@ -396,7 +389,7 @@ const GroupDataTable = () => {
                         <TableCell>{student.name}</TableCell>
                         <TableCell>{student.last_name}</TableCell>
                         <TableCell>{student.email}</TableCell>
-                        <>
+                        
                           {/* index 0 para renderizar esto una vez por fila de equipo (y no una por estudiante) */}
                           {index === 0 && (
                             <TableCell
@@ -420,44 +413,42 @@ const GroupDataTable = () => {
 
                           {/* Las tres preferencias */}
                           {index === 0 && (
+                            
+                            (!group.preferred_topics || (group.preferred_topics.length === 0)) ? (
                             <>
-                                { (!group.preferred_topics || (group.preferred_topics.length === 0)) ? (
-                                  <>
-                                    <ExpandableCell show={showExtraColumns} rowSpan={group.students.length} align="center">
-                                      {"N/A"}
-                                    </ExpandableCell>
-                                    <ExpandableCell show={showExtraColumns} rowSpan={group.students.length} align="center">
-                                      {"N/A"}
-                                    </ExpandableCell>
-                                    <ExpandableCell show={showExtraColumns} rowSpan={group.students.length} align="center">
-                                      {"N/A"}
-                                    </ExpandableCell>
-                                  </>
-                                ) : (
-                                  <>
-                                    <ExpandableCell show={showExtraColumns} rowSpan={group.students.length}>
-                                      {getTopicNameById(
-                                        group.preferred_topics[0]
-                                      ) || ""}
-                                    </ExpandableCell>
-
-                                    <ExpandableCell show={showExtraColumns} rowSpan={group.students.length}>
-                                      {getTopicNameById(
-                                        group.preferred_topics[1]
-                                      ) || ""}
-                                    </ExpandableCell>
-
-                                    <ExpandableCell show={showExtraColumns} rowSpan={group.students.length}>
-                                      {getTopicNameById(
-                                        group.preferred_topics[2]
-                                      ) || ""}
-                                    </ExpandableCell>
-                                  </>
-                                )}
+                              <ExpandableCell show={showExtraColumns} rowSpan={group.students.length} align="center">
+                                {"N/A"}
+                              </ExpandableCell>
+                              <ExpandableCell show={showExtraColumns} rowSpan={group.students.length} align="center">
+                                {"N/A"}
+                              </ExpandableCell>
+                              <ExpandableCell show={showExtraColumns} rowSpan={group.students.length} align="center">
+                                {"N/A"}
+                              </ExpandableCell>
                             </>
-                          )}
-                        </>
+                          ) : (
+                            <>
+                              <ExpandableCell show={showExtraColumns} rowSpan={group.students.length}>
+                                {getTopicNameById(
+                                  group.preferred_topics[0]
+                                ) || ""}
+                              </ExpandableCell>
 
+                              <ExpandableCell show={showExtraColumns} rowSpan={group.students.length}>
+                                {getTopicNameById(
+                                  group.preferred_topics[1]
+                                ) || ""}
+                              </ExpandableCell>
+
+                              <ExpandableCell show={showExtraColumns} rowSpan={group.students.length}>
+                                {getTopicNameById(
+                                  group.preferred_topics[2]
+                                ) || ""}
+                              </ExpandableCell>
+                            </>
+                          )                            
+                          )}
+                        
                         {/* Copypasteo desde ParentTable esta sección de los botones, ver [] */}
                         {index === 0 && (
                           <TableCell rowSpan={group.students.length}>
@@ -517,12 +508,10 @@ const GroupDataTable = () => {
             status={notification.status}
           />
         </>
-
-
       )}
 
     </Box>
-  );
+  )
 };
 
 export default GroupDataTable;

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -19,7 +19,7 @@ import ExpandableCell from "../ExpandableCell";
 
 import { TeamModal } from "../UI/Tables/Modals/teamModal";
 import { setGroups } from "../../redux/slices/groupsSlice";
-import { editGroup } from "../../api/sendGroupForm";
+import { editTeam } from "../../api/sendGroupForm";
 import MySnackbar from "../UI/MySnackBar";
 import { getTableData } from "../../api/handleTableData";
 
@@ -46,7 +46,7 @@ const GroupDataTable = () => {
   .filter(item => Object.keys(item).length > 0);
 
   const [allTopics, setAllTopics] = useState({csvTopics: topics, customTopics: []});
-  const [data, setData] = useState(groups);
+  const [data, setData] = useState(groups); // teams
 
   const [showExtraColumns, setShowExtraColumns] = useState(false);
 
@@ -98,12 +98,12 @@ const GroupDataTable = () => {
   const handleEditItem = async (editedItem, setEditedItem, handleCloseEditModal, confirm_option=false) => {
     try {
       editedItem.tutor_email = getTutorEmailByTutorPeriodId(editedItem.tutor_period_id, period.id);
-      await editItemInGenericTable(editGroup, editedItem, setEditedItem, setGroups, confirm_option);
+      await editItemInGenericTable(editTeam, editedItem, setEditedItem, setGroups, confirm_option);
       
       // Close modal de edición en caso de éxito
       handleCloseEditModal();
       setOriginalEditedItemId(null); // AUX: Agrego esto acá.
-      setEditedItem({}); // necesario para el segundo modal, el de confirm.
+      setEditedItem({}); // necesario para el segundo modal, el de confirm.      
     } catch (err) {
       const title="team";
       console.error(`Error when editing ${title}:`, err);
@@ -129,18 +129,18 @@ const GroupDataTable = () => {
     }
   };
   const editItemInGenericTable = async (apiEditFunction, editedItem, setEditedItem, setReducer, confirm_option=false) => {    
-    const item = await apiEditFunction(editedItem.id, period.id, editedItem, user, confirm_option);
+    const changes = await apiEditFunction(editedItem.id, period.id, editedItem, user, confirm_option);
     setNotification({
       open: true,
       message: `Se editó equipo exitosamente`,
       status: "success",
     });
+    // Si es éxito, hay que adaptar los datos de la lista a mostrar en la tabla
+    // AUX: EN CONSTRUCCIÓN - ESTO ADAPTA EL EQUIPO ACTUAL SEGÚN LO QUE MANDÉ PERO
+    // TIENE TMB QUE ADAPTAR LOS 'EQUIPOS ANTERIORES' SI HABÍA CONFLICTO, back debe responder
     setData((prevData) =>
-      prevData.map((existingItem) => (existingItem.id === originalEditedItemId ? item : existingItem))
-    );
-    dispatch(setReducer((prevData) =>
-      prevData.map((existingItem) => (existingItem.id === originalEditedItemId ? item : existingItem)))
-    );
+      prevData.map((existingTeam) => (existingTeam.id === editedItem.id ? editedItem : existingTeam))
+    );    
   };
   const [notification, setNotification] = useState({
     open: false,

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -45,7 +45,8 @@ const GroupDataTable = () => {
   .map(({ version, rehydrated, ...rest }) => rest)
   .filter(item => Object.keys(item).length > 0);
 
-  const [allTopics, setAllTopics] = useState(topics);
+  const [allTopics, setAllTopics] = useState({csvTopics: topics, customTopics: []});
+  //const [customTopics, setCustomTopics] = useState();
   // const addCustomTopicsToAllTopics = () => {
   //   // Workaround a que el back no los devuelva
   //   // agrego los temas de quienes pusieron "Ya tengo tema y tutor"
@@ -53,12 +54,9 @@ const GroupDataTable = () => {
   //   .map(team => team.topic);
   //   console.log("### Custom topics:", customTopics);
   //   setAllTopics((prevData) => [...prevData, ...customTopics]);
-  // }
-  const customTopics = groups.filter(team => !topics.some(t => t.id === team.topic.id))
-    .map(team => team.topic);
-    console.log("### Custom topics:", customTopics);
-  const constAllTopics = topics.concat(customTopics);
-
+  // }  
+  
+  //const constAllTopics = topics.concat(customTopics);
 
   const [showExtraColumns, setShowExtraColumns] = useState(false);
 
@@ -81,12 +79,18 @@ const GroupDataTable = () => {
   const dispatch = useDispatch();
 
   /// Los useEffect los pongo acá
-  const endpoint = `/teams/?period=${period.id}`;
+  const endpoint = `/groups/?period=${period.id}`;
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         const responseData = await getTableData(endpoint, user);
+
+        // Workaround a que el back no los devuelva: temas de "Ya tengo tema y tutor":
+        const customTopics = groups.filter(team => !topics.some(t => t.id === team.topic.id))
+        .map(team => team.topic);
+        console.log("### Custom topics:", customTopics);
+        setAllTopics({csvTopics: topics, customTopics: customTopics});
         
         console.log("Response data:", responseData);
         setData(responseData);
@@ -100,6 +104,7 @@ const GroupDataTable = () => {
 
     fetchData();
   }, [endpoint, user]);
+  //}, [endpoint, user, groups, topics]);
 
   // useEffect(() => {
   //   // if (groups.length > 0) {
@@ -555,8 +560,8 @@ const GroupDataTable = () => {
             conflictMsg={conflictsMessage}
             setConflictMsg={setConflictsMessage}
 
-            //topics={allTopics}
-            topics={constAllTopics}            
+            topics={allTopics}
+            //topics={constAllTopics}            
             tutors={tutors}
             students={students}
             periodId={period.id}

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -9,10 +9,13 @@ import {
   TableRow,
   TextField,
   Button,
+  Collapse,
+  Box
 } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
-import { Box } from "@mui/system";
+//import { Box } from "@mui/system";
+import ExpandableCell from "../ExpandableCell";
 
 // Componente para la tabla de equipos
 const GroupDataTable = () => {
@@ -154,6 +157,8 @@ const GroupDataTable = () => {
     URL.revokeObjectURL(url);
   };
 
+  const [showExtraColumns, setShowExtraColumns] = useState(false);
+
   return (
     <Box>
       {loading ? (
@@ -178,6 +183,11 @@ const GroupDataTable = () => {
           >
             Descargar CSV
           </Button>
+
+          <Button onClick={() => setShowExtraColumns(prev => !prev)}>
+            {showExtraColumns ? "Ocultar preferencias" : "Mostrar preferencias"}
+          </Button>
+
           <TableContainer component={Paper}>
             <Table
               stickyHeader
@@ -185,7 +195,7 @@ const GroupDataTable = () => {
               aria-label="simple table"
             >
               <TableHead>
-                <TableRow>
+                <TableRow sx={{ backgroundColor: (theme) => theme.palette.action.hover }}>
                   <TableCell sx={{ fontWeight: "bold" }}>Equipo número</TableCell>
 
                   <TableCell sx={{ fontWeight: "bold" }}>Padrón</TableCell>
@@ -196,9 +206,38 @@ const GroupDataTable = () => {
                   <TableCell sx={{ fontWeight: "bold" }}>Tutor</TableCell>
                   <TableCell sx={{ fontWeight: "bold" }}>Tema asignado</TableCell>
 
-                  <TableCell sx={{ fontWeight: "bold" }}>Preferencia 1</TableCell>
-                  <TableCell sx={{ fontWeight: "bold" }}>Preferencia 2</TableCell>
-                  <TableCell sx={{ fontWeight: "bold" }}>Preferencia 3</TableCell>
+                    
+                  {/*<TableCell 
+                    sx={{
+                      fontWeight: "bold",
+                      transition: 'all 0.5s ease',
+                      opacity: showExtraColumns ? 1 : 0,
+                      transform: showExtraColumns ? 'scaleX(1)' : 'scaleX(0)',
+                      transformOrigin: 'left',
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      width: showExtraColumns ? 'auto' : 0,
+                      padding: showExtraColumns ? '16px' : 0,
+                    }}
+                  >*/}
+                  <ExpandableCell show={showExtraColumns} isHeader>
+                      Preferencia 1
+                  </ExpandableCell>
+                  <ExpandableCell show={showExtraColumns} isHeader>
+                      Preferencia 2
+                  </ExpandableCell>
+                  <ExpandableCell show={showExtraColumns} isHeader>
+                      Preferencia 3
+                  </ExpandableCell>
+                  
+
+                  <TableCell sx={{ fontWeight: "bold" }}>
+                    <Button onClick={() => setShowExtraColumns(prev => !prev)}>
+                      {showExtraColumns ? "Ocultar preferencias" : "Mostrar preferencias"}
+                    </Button>
+                  </TableCell>
+                  
+                  
                 </TableRow>
               </TableHead>
 
@@ -222,6 +261,7 @@ const GroupDataTable = () => {
                         <TableCell>{student.last_name}</TableCell>
                         <TableCell>{student.email}</TableCell>
                         <>
+                          {/* index 0 para renderizar esto una vez por fila de equipo (y no una por estudiante) */}
                           {index === 0 && (
                             <TableCell
                               rowSpan={group.students.length}
@@ -243,46 +283,69 @@ const GroupDataTable = () => {
                           )}
                           {index === 0 && (
                             <>
-                              { (!group.preferred_topics || (group.preferred_topics.length === 0)) ? (
-                                <>
-                                  <TableCell
-                                    rowSpan={group.students.length}
-                                    align="center"
-                                  >
-                                    {"N/A"}
-                                  </TableCell>
-                                  <TableCell
-                                    rowSpan={group.students.length}
-                                    align="center"
-                                  >
-                                    {"N/A"}
-                                  </TableCell>
-                                  <TableCell
-                                    rowSpan={group.students.length}
-                                    align="center"
-                                  >
-                                    {"N/A"}
-                                  </TableCell>
-                                </>
-                              ) : (
-                                <>
-                                  <TableCell rowSpan={group.students.length}>
-                                    {getTopicNameById(
-                                      group.preferred_topics[0]
-                                    ) || ""}
-                                  </TableCell>
-                                  <TableCell rowSpan={group.students.length}>
-                                    {getTopicNameById(
-                                      group.preferred_topics[1]
-                                    ) || ""}
-                                  </TableCell>
-                                  <TableCell rowSpan={group.students.length}>
-                                    {getTopicNameById(
-                                      group.preferred_topics[2]
-                                    ) || ""}
-                                  </TableCell>
-                                </>
-                              )}
+                                { (!group.preferred_topics || (group.preferred_topics.length === 0)) ? (
+                                  <>
+                                    {/*<TableCell
+                                      rowSpan={group.students.length}
+                                      align="center"
+                                    >
+                                      {"N/A"}
+                                    </TableCell>
+                                    <TableCell
+                                      rowSpan={group.students.length}
+                                      align="center"
+                                    >
+                                      {"N/A"}
+                                    </TableCell>
+                                    <TableCell
+                                      rowSpan={group.students.length}
+                                      align="center"
+                                    >
+                                      {"N/A"}
+                                    </TableCell>
+                                    */}
+
+
+                                    <ExpandableCell show={showExtraColumns} rowSpan={group.students.length} align="center">
+                                      {"N/A"}
+                                    </ExpandableCell>
+                                    <ExpandableCell show={showExtraColumns} rowSpan={group.students.length} align="center">
+                                      {"N/A"}
+                                    </ExpandableCell>
+                                    <ExpandableCell show={showExtraColumns} rowSpan={group.students.length} align="center">
+                                      {"N/A"}
+                                    </ExpandableCell>
+                                    
+
+
+                                  </>
+                                ) : (
+                                  
+
+                                  <>
+
+                                    <ExpandableCell show={showExtraColumns} rowSpan={group.students.length}>
+                                      {getTopicNameById(
+                                        group.preferred_topics[0]
+                                      ) || ""}
+                                    </ExpandableCell>
+
+                                    <ExpandableCell show={showExtraColumns} rowSpan={group.students.length}>
+                                      {getTopicNameById(
+                                        group.preferred_topics[1]
+                                      ) || ""}
+                                    </ExpandableCell>
+
+                                    <ExpandableCell show={showExtraColumns} rowSpan={group.students.length}>
+                                      {getTopicNameById(
+                                        group.preferred_topics[2]
+                                      ) || ""}
+                                    </ExpandableCell>
+                                  </>
+
+
+
+                                )}
                             </>
                           )}
                         </>

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -138,10 +138,10 @@ const GroupDataTable = () => {
       changes.edited.forEach((team) => {
         const idx = updated.findIndex((prevDataTeam) => prevDataTeam.id === team.id);
         if (idx >= 0) {
-          // reemplazo si ya existía
+          // reenplazar si ya existía
           updated[idx] = team;
         } else {
-          // o agrego si no estaba en la lista [aux: por qué no estaría en la lista si es un edit y no un add?]
+          // o agregar si no estaba en la lista (no debería darse este caso en un edit en realidad)
           updated.push(team);
         }
       });

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -135,12 +135,28 @@ const GroupDataTable = () => {
       message: `Se editó equipo exitosamente`,
       status: "success",
     });
-    // Si es éxito, hay que adaptar los datos de la lista a mostrar en la tabla
-    // AUX: EN CONSTRUCCIÓN - ESTO ADAPTA EL EQUIPO ACTUAL SEGÚN LO QUE MANDÉ PERO
-    // TIENE TMB QUE ADAPTAR LOS 'EQUIPOS ANTERIORES' SI HABÍA CONFLICTO, back debe responder
-    setData((prevData) =>
-      prevData.map((existingTeam) => (existingTeam.id === editedItem.id ? editedItem : existingTeam))
-    );    
+    // Si es éxito, hay que adaptar los datos de la lista a mostrar en la tabla    
+    setData((prevData) => {
+      let updated = [...prevData];
+
+      // Reemplazar o agregar los equipos editados
+      changes.edited.forEach((team) => {
+        const idx = updated.findIndex((prevDataTeam) => prevDataTeam.id === team.id);
+        if (idx >= 0) {
+          // reemplazo si ya existía
+          updated[idx] = team;
+        } else {
+          // o agrego si no estaba en la lista
+          updated.push(team);
+        }
+      });
+
+      // Eliminar equipos borrados (me quedo con los equipos que No incluye la lista de deleted)
+      updated = updated.filter((prevDataTeam) => !changes.deleted.includes(prevDataTeam.id));
+
+      return updated;
+    });
+              
   };
   const [notification, setNotification] = useState({
     open: false,

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -64,6 +64,11 @@ const GroupDataTable = () => {
     try {
       editedItem.tutor_email = getTutorEmailByTutorPeriodId(editedItem.tutor_period_id, period.id);
       await editItemInGenericTable(editGroup, editedItem, setEditedItem, setGroups, confirm_option);
+      
+      // Close modal de edición en caso de éxito
+      handleCloseEditModal();
+      setOriginalEditedItemId(null); // AUX: Agrego esto acá.
+      setEditedItem({}); /////
     } catch (err) {
       const title="groups";
       console.error(`Error when editing ${title}:`, err);
@@ -72,9 +77,11 @@ const GroupDataTable = () => {
         message: `Error al editar equipo.`,
         status: "error",
       });
+      console.log("--- CONFLICTO, VOY A ABRIR EL MODAL DE CONFIRMACIÓN ACTUALMENTE CERRADO". openConfirmEditModal);
 
       // Probando, hay que abrir otro modal o alert para mostrar el msj (que no me acuerdo si devolví desde el back)
       // y pedirle confirmación (entonces mandar el confirm en true) o cancelar y no hacer nada.
+      // Si hay conflicto, no cerrar el modal de edición. Abrir cartel de confirmación y si se cancela
       if (err.response?.status===409) {
         setNotification({
           open: true,
@@ -83,16 +90,15 @@ const GroupDataTable = () => {
         });
 
         setOpenConfirmEditModal(true);
+        console.log("--- HE ABIERTO EL MODAL DE CONFIRMACIÓN". openConfirmEditModal);
         
       }
     } finally {
-      handleCloseEditModal(true);
+      
     }
   };
   const editItemInGenericTable = async (apiEditFunction, editedItem, setEditedItem, setReducer, confirm_option=false) => {    
     const item = await apiEditFunction(originalEditedItemId, period.id, editedItem, user, confirm_option);
-    setEditedItem({});
-    setOriginalEditedItemId(null);
     setNotification({
       open: true,
       message: `Se editó equipo exitosamente`,
@@ -116,8 +122,15 @@ const GroupDataTable = () => {
   /////
   // Confirmar edición con bool true
   const handleConfirmEditOnConflict = async (editedItem, setEditedItem, handleCloseEditModal, confirm_option=true) => {
-    await handleEditItem(editedItem, setEditedItem, handleCloseEditModal, true);
+    try {
+      console.log("--- CONFIRMAR API CALL A PUNTO DE HACERSE");
+      await handleEditItem(editedItem, setEditedItem, handleCloseEditModal, true);
+      console.log("--- CONFIRMAR API CALL HECHA");
+    } catch(err) {
+      console.log("--- CONFIRMAR API CALL ERRÓNEA:", err);
+    }
   };
+  console.log("--- HOLA ----- MODAL DE CONFIRMACIÓN, abierto?:". openConfirmEditModal);
   //////
   // Formato
   const getTutorEmailByTutorPeriodId = (id, periodId) => {

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -1,3 +1,6 @@
+/// Este archivo es similar a ParentTable, pero tanto el contenido de la tabla que se renderiza como
+// el flujo de editar equipo (con dos modales, analizando si hubo o no conflicto) es diferente a ParentTable,
+// por lo que se optó por mantener los archivos separados en pos de la legibilidad.
 import {
   CircularProgress,
   Paper,
@@ -13,7 +16,7 @@ import {
   Stack
 } from "@mui/material";
 import React, { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import ExpandableCell from "../ExpandableCell";
 
 import { TeamModal } from "../UI/Tables/Modals/teamModal";
@@ -44,6 +47,9 @@ const GroupDataTable = () => {
   .map(({ version, rehydrated, ...rest }) => rest)
   .filter(item => Object.keys(item).length > 0);
 
+  const user = useSelector((state) => state.user);
+  const [loading, setLoading] = useState(true);
+
   const [allTopics, setAllTopics] = useState({csvTopics: topics, customTopics: []});
   const [data, setData] = useState(groups); // teams
 
@@ -53,19 +59,13 @@ const GroupDataTable = () => {
   const [showNoTopic, setShowNoTopic] = useState(false);
   const [showNoTutor, setShowNoTutor] = useState(false);
 
-  const [loading, setLoading] = useState(true);
-
-  ////////// Inicio lo necesario para editar equipo, Revisar []
-  const user = useSelector((state) => state.user);
   const [openConfirmEditModal, setOpenConfirmEditModal] = useState(false);
   const [conflictsMessage, setConflictsMessage] = useState([]);
-  // Editar equipo
+
   const [openEditModal, setOpenEditModal] = useState(false);
   const [itemToPassToModal, setItemToPassToModal] = useState(null);
-  
-  const dispatch = useDispatch();
 
-  /// useEffect
+  // useEffect
   const endpoint = `/groups/?period=${period.id}`;
 
   useEffect(() => {
@@ -90,9 +90,8 @@ const GroupDataTable = () => {
     fetchData();
   }, [endpoint, user]);
   //}, [endpoint, user, groups, topics]);
-  /// fin useEffect
 
-  // Aux: Editar equipo, la traigo copypaste, veré de refactorizar para reutilizar después []
+  // Editar equipo
   const handleEditItem = async (editedItem, setEditedItem, handleCloseEditModal, confirm_option=false) => {
     try {
       editedItem.tutor_email = getTutorEmailByTutorPeriodId(editedItem.tutor_period_id, period.id);
@@ -162,13 +161,13 @@ const GroupDataTable = () => {
   const handleSnackbarClose = () => {
     setNotification({ ...notification, open: false });
   };
-  /////
+  
   // Confirmar edición con bool true
   const handleConfirmEditOnConflict = async (editedItem, setEditedItem, handleCloseEditModal, confirm_option=true) => {
     await handleEditItem(editedItem, setEditedItem, handleCloseEditModal, true);
   };
-  //////
-  // Formato
+  
+  // Formato para el endpoint
   const getTutorEmailByTutorPeriodId = (id, periodId) => {
     const tutor = tutors.find(
     (t) =>
@@ -176,9 +175,7 @@ const GroupDataTable = () => {
         t.tutor_periods.some((tp) => tp.period_id === periodId && tp.id === id)
     );
     return tutor ? tutor.email : "Sin asignar"; // Si no encuentra el tutor, mostrar 'Sin asignar'
-  };    
-  //////////////////// fin lo necesario para edit ///////  
-
+  };
 
   // Función para obtener el nombre del topic por su id
   // aux: se usa solo para preferencias, no es problema que use topics
@@ -222,7 +219,6 @@ const GroupDataTable = () => {
     return showNoTopic ? teams.filter((team) => !team.topic) : teams
   };
   const showTeamsWithNoTutor = (teams) => {
-    console.log("--- teams:", teams);
     return showNoTutor ? teams.filter((team) => !team.tutor_period_id) : teams
   };
   // Filtrar equipos según el término de búsqueda
@@ -246,7 +242,6 @@ const GroupDataTable = () => {
   );
   // Contemplo si se clickeó botones de showNoX: obtengo solo los que no tienen topic y/o tutor, o bien conservo lo que ya tenía, según el bool
   const filteredTeams = showTeamsWithNoTopic(showTeamsWithNoTutor(filteredTeamsBySearchTerm));
-  console.log("filteredTeams:", filteredTeams);
   // Función para descargar los datos en formato CSV
   const downloadCSV = () => {
     const csvRows = [];
@@ -311,8 +306,6 @@ const GroupDataTable = () => {
     a.click();
     URL.revokeObjectURL(url);
   };
-
-  console.log("allTopics:", allTopics);
 
   return (
     <Box>      

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -78,7 +78,7 @@ const GroupDataTable = () => {
     setOriginalEditedItemId(null);
     setNotification({
       open: true,
-      message: `Se editó Equipo||''} exitosamente`,
+      message: `Se editó Equipo exitosamente`,
       status: "success",
     });
     setData((prevData) =>

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -213,6 +213,7 @@ const GroupDataTable = () => {
 
   const [showExtraColumns, setShowExtraColumns] = useState(false);
 
+  console.log("--- filteredGroups:", filteredGroups);
   return (
     <Box>
       {loading ? (

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -14,7 +14,7 @@ import {
   Stack
 } from "@mui/material";
 import React, { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 //import { Box } from "@mui/system";
 import ExpandableCell from "../ExpandableCell";
 
@@ -44,11 +44,16 @@ const GroupDataTable = () => {
 
   const [loading, setLoading] = useState(true);
 
+  ////////// Inicio lo necesario para editar equipo, Revisar []
+  const user = useSelector((state) => state.user);
   //const [openAddModal, setOpenAddModal] = useState(false);
   // Editar equipo
   const [openEditModal, setOpenEditModal] = useState(false);
   const [originalEditedItemId, setOriginalEditedItemId] = useState(null);
   const [itemToPassToModal, setItemToPassToModal] = useState(null);
+  
+  const [data, setData] = useState([]);
+  const dispatch = useDispatch();
   // Aux: Editar equipo, la traigo copypaste, veré de refactorizar para reutilizar después []
   const handleEditItem = async (editedItem, setEditedItem, handleCloseEditModal) => {
     try {
@@ -81,6 +86,12 @@ const GroupDataTable = () => {
       prevData.map((existingItem) => (existingItem.id === originalEditedItemId ? item : existingItem)))
     );
   };
+  const [notification, setNotification] = useState({
+    open: false,
+    message: "",
+    status: "",
+  });
+  //////////////////// fin lo necesario para edit ///////
 
   useEffect(() => {
     if (groups.length > 0) {
@@ -353,25 +364,26 @@ const GroupDataTable = () => {
                         </>
 
                         {/* Copypasteo desde ParentTable esta sección de los botones, ver [] */}
-                        <TableCell>
-                          <Stack direction="row" spacing={1}>                          
-                            <Button
-                              onClick={() => {setOpenEditModal(true); setItemToPassToModal(group)}}
-                              style={{ backgroundColor: "#e0711d", color: "white" }} //botón naranja
-                              >
-                              Editar
-                            </Button>
-                          
-                            {false && (
+                        {index === 0 && (
+                          <TableCell rowSpan={group.students.length}>
+                            <Stack direction="row" spacing={1}>                          
                               <Button
-                                onClick={() => handleDelete(item.id)}
-                                style={{ backgroundColor: "red", color: "white" }}
+                                onClick={() => {setOpenEditModal(true); setItemToPassToModal(group)}}
+                                style={{ backgroundColor: "#e0711d", color: "white" }} //botón naranja
                                 >
-                                Eliminar
+                                Editar
                               </Button>
-                            )}
-                          </Stack>
-                        </TableCell>
+                            
+                              {false && (
+                                <Button
+                                  style={{ backgroundColor: "red", color: "white" }}
+                                  >
+                                  Eliminar
+                                </Button>
+                              )}
+                            </Stack>
+                          </TableCell>
+                        )}
 
                       </TableRow>
                     ))}

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -58,6 +58,7 @@ const GroupDataTable = () => {
   // Aux: Editar equipo, la traigo copypaste, veré de refactorizar para reutilizar después []
   const handleEditItem = async (editedItem, setEditedItem, handleCloseEditModal) => {
     try {
+      editedItem.tutor_email = getTutorEmailByTutorPeriodId(editedItem.tutor_period_id, period.id);
       await editItemInGenericTable(editGroup, editedItem, setEditedItem, setGroups);
     } catch (err) {
       const title="groups";
@@ -95,6 +96,16 @@ const GroupDataTable = () => {
   const handleSnackbarClose = () => {
     setNotification({ ...notification, open: false });
   };
+  /////
+  // Formato
+  const getTutorEmailByTutorPeriodId = (id, periodId) => {
+    const tutor = tutors.find(
+    (t) =>
+        t.tutor_periods &&
+        t.tutor_periods.some((tp) => tp.period_id === periodId && tp.id === id)
+    );
+    return tutor ? tutor.email : "Sin asignar"; // Si no encuentra el tutor, mostrar 'Sin asignar'
+  };    
   //////////////////// fin lo necesario para edit ///////
 
   useEffect(() => {
@@ -412,6 +423,7 @@ const GroupDataTable = () => {
 
             topics={topics}
             tutors={tutors}
+            periodId={period.id}
           />  
           <MySnackbar
             open={notification.open}

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -95,7 +95,7 @@ const GroupDataTable = () => {
     }
   };
   const editItemInGenericTable = async (apiEditFunction, editedItem, setEditedItem, setReducer, confirm_option=false) => {    
-    const item = await apiEditFunction(originalEditedItemId, period.id, editedItem, user, confirm_option);
+    const item = await apiEditFunction(editedItem.id, period.id, editedItem, user, confirm_option);
     setNotification({
       open: true,
       message: `Se editó equipo exitosamente`,

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -50,7 +50,7 @@ const GroupDataTable = () => {
 
   ////////// Inicio lo necesario para editar equipo, Revisar []
   const user = useSelector((state) => state.user);
-  const [openConfirmEditModal, setOpenConfirmEditModal] = useState(false); // [] aux: los voy a pasar en el lugar del add, VOLVER
+  const [openConfirmEditModal, setOpenConfirmEditModal] = useState(false);
   const [conflictsMessage, setConflictsMessage] = useState([]);
   // Editar equipo
   const [openEditModal, setOpenEditModal] = useState(false);
@@ -459,9 +459,9 @@ const GroupDataTable = () => {
             item={itemToPassToModal}
             setParentItem={setItemToPassToModal}
 
-            openAddModal={openConfirmEditModal}
-            setOpenAddModal={setOpenConfirmEditModal}
-            handleAddItem={handleConfirmEditOnConflict}
+            openConfirmModal={openConfirmEditModal}
+            setOpenConfirmModal={setOpenConfirmEditModal}
+            handleConfirm={handleConfirmEditOnConflict}
 
             conflictMsg={conflictsMessage}
             setConflictMsg={setConflictsMessage}

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -247,18 +247,28 @@ const GroupDataTable = () => {
             onChange={(e) => setSearchTerm(e.target.value)}
             sx={{ marginBottom: 2 }}
           />
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={downloadCSV}
-            sx={{ marginBottom: 2 }}
+          <Box
+            sx={{ 
+              display: 'flex', 
+              justifyContent: 'space-between', 
+              marginBottom: 2 
+            }}
           >
-            Descargar CSV
-          </Button>
+            
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={downloadCSV}
+              sx={{ marginBottom: 2 }}
+            >
+              Descargar CSV
+            </Button>
 
-          <Button onClick={() => setShowExtraColumns(prev => !prev)}>
-            {showExtraColumns ? "Ocultar preferencias" : "Mostrar preferencias"}
-          </Button>
+            <Button variant="outlined" color="primary" 
+              onClick={() => setShowExtraColumns(prev => !prev)}>
+              {showExtraColumns ? "Ocultar preferencias" : "Mostrar preferencias"}
+            </Button>
+          </Box>
 
           <TableContainer component={Paper}>
             <Table

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -433,7 +433,7 @@ const GroupDataTable = () => {
                 {filteredTeams.map((team) => (
                   <React.Fragment key={team.id}>
                     <TableRow sx={{ backgroundColor: "#f0f0f0" }}>
-                      <TableCell colSpan={10} align="center"></TableCell>
+                      <TableCell colSpan={12} align="center"></TableCell>
                     </TableRow>
                     {/* Table content */}
                     <TableCell

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -41,6 +41,10 @@ const GroupDataTable = () => {
     .map(({ version, rehydrated, ...rest }) => rest)
     .filter((item) => Object.keys(item).length > 0);
 
+  const students = Object.values(useSelector((state) => state.students))
+  .map(({ version, rehydrated, ...rest }) => rest)
+  .filter(item => Object.keys(item).length > 0);
+
   const [searchTerm, setSearchTerm] = useState("");
 
   const [loading, setLoading] = useState(true);
@@ -433,6 +437,7 @@ const GroupDataTable = () => {
 
             topics={topics}
             tutors={tutors}
+            students={students}
             periodId={period.id}
           />  
           <MySnackbar

--- a/src/components/ExpandableCell.js
+++ b/src/components/ExpandableCell.js
@@ -1,0 +1,49 @@
+import React from "react";
+import TableCell from "@mui/material/TableCell";
+import { useTheme } from "@mui/material/styles";
+
+function ExpandableCell({ show, rowSpan, children, isHeader = false }) {
+  const theme = useTheme();
+
+  //if (!show) return null;
+
+  return (
+    <TableCell
+      rowSpan={show ? rowSpan : 1}
+      sx={{
+        fontWeight: isHeader ? "bold" : "normal",
+        backgroundColor: isHeader
+          ? theme.palette.grey[100]
+          : "transparent",
+
+        transition: "all 0.5s ease",
+        opacity: show ? 1 : 0,
+        transform: show ? "scaleX(1)" : "scaleX(0)",
+        transformOrigin: "left",
+        //whiteSpace: "nowrap",
+        overflow: "hidden",
+        //width: show ? 200 : 0,
+        //padding: show ? "16px" : 0,
+
+
+        whiteSpace: "normal",          // Permitir salto de línea
+        //maxWidth: 3000,                 // Limitar ancho máximo para que no estire la tabla
+        // este colapsa bien pero al abrir tienen 1 letra c/u //wordBreak: "break-word",       // Romper palabras largas para no desbordar
+
+
+        // A VER 
+
+        wordBreak: "break-word",    
+
+        width: show ? "auto" : 0,
+        minWidth: show ? 100 : 0,
+        maxWidth: show ? 200 : 0,
+        //padding: show ? (isHeader ? "16px" : undefined) : 0,
+      }}
+    >
+      {children}
+    </TableCell>
+  );
+}
+
+export default ExpandableCell;

--- a/src/components/ExpandableCell.js
+++ b/src/components/ExpandableCell.js
@@ -33,10 +33,10 @@ function ExpandableCell({ show, rowSpan, children, isHeader = false }) {
 
         // A VER 
 
-        wordBreak: "break-word",    
+        //wordBreak: "break-word",    
 
         width: show ? "auto" : 0,
-        minWidth: show ? 100 : 0,
+        minWidth: show ? 200 : 0,
         maxWidth: show ? 200 : 0,
         //padding: show ? (isHeader ? "16px" : undefined) : 0,
       }}

--- a/src/components/ExpandableCell.js
+++ b/src/components/ExpandableCell.js
@@ -5,8 +5,6 @@ import { useTheme } from "@mui/material/styles";
 function ExpandableCell({ show, rowSpan, children, isHeader = false }) {
   const theme = useTheme();
 
-  //if (!show) return null;
-
   return (
     <TableCell
       rowSpan={show ? rowSpan : 1}
@@ -20,25 +18,13 @@ function ExpandableCell({ show, rowSpan, children, isHeader = false }) {
         opacity: show ? 1 : 0,
         transform: show ? "scaleX(1)" : "scaleX(0)",
         transformOrigin: "left",
-        //whiteSpace: "nowrap",
         overflow: "hidden",
-        //width: show ? 200 : 0,
-        //padding: show ? "16px" : 0,
-
 
         whiteSpace: "normal",          // Permitir salto de línea
-        //maxWidth: 3000,                 // Limitar ancho máximo para que no estire la tabla
-        // este colapsa bien pero al abrir tienen 1 letra c/u //wordBreak: "break-word",       // Romper palabras largas para no desbordar
-
-
-        // A VER 
-
-        //wordBreak: "break-word",    
 
         width: show ? "auto" : 0,
         minWidth: show ? 200 : 0,
         maxWidth: show ? 200 : 0,
-        //padding: show ? (isHeader ? "16px" : undefined) : 0,
       }}
     >
       {children}

--- a/src/components/Forms/StudentForm.js
+++ b/src/components/Forms/StudentForm.js
@@ -337,7 +337,8 @@ const StudentForm = () => {
                   </FormControl>
                 </>
               )}
-  
+
+              {/* Ya tengo tema y tutor */}
               {formData.selectedOption === "existing" && (
                 <>
                   <TextField

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -99,7 +99,7 @@ export const TeamModal = ({
                   autoFocus
                   margin="normal"
                   label="Padrón integrante 1"
-                  value={item && item["students"] && item["students"][0] || ""}
+                  value={item && item["students"] && item["students"][0] && item["students"][0]["id"] || ""}
                   required
                   onChange={(e) =>
                     setItem({ ...item, student_id_1: parseInt(e.target.value) })
@@ -114,7 +114,7 @@ export const TeamModal = ({
                   autoFocus
                   margin="normal"
                   label="Padrón integrante 2"
-                  value={item && item["students"] && item["students"][1] || ""}
+                  value={item && item["students"] && item["students"][1] && item["students"][1]["id"] || ""}
                   required
                   onChange={(e) =>
                     setItem({ ...item, student_id_2: parseInt(e.target.value) })
@@ -129,7 +129,7 @@ export const TeamModal = ({
                   autoFocus
                   margin="normal"
                   label="Padrón integrante 3"
-                  value={item && item["students"] && item["students"][2] || ""}
+                  value={item && item["students"] && item["students"][2] && item["students"][2]["id"] || ""}
                   required
                   onChange={(e) =>
                     setItem({ ...item, student_id_3: parseInt(e.target.value) })
@@ -144,7 +144,7 @@ export const TeamModal = ({
                   autoFocus
                   margin="normal"
                   label="Padrón integrante 4"
-                  value={item && item["students"] && item["students"][3] || ""}
+                  value={item && item["students"] && item["students"][3] && item["students"][3]["id"] || ""}
                   required
                   onChange={(e) =>
                     setItem({ ...item, student_id_4: parseInt(e.target.value) })
@@ -159,7 +159,7 @@ export const TeamModal = ({
                       name="topic2"
                       value={item.topic?.name || "Sin asignar!!! VERRRRRR"}
                       onChange={(e) =>
-                        setItem({ ...item, topic_id: 1 }) 
+                        setItem({ ...item, topic_id: item.topic?.id }) 
                       }
                       label="Tema"
                       required

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -12,11 +12,13 @@ import {
     InputLabel,
     //
     FormControl,
-    Typography
+    Typography,
+    Fab
 } from "@mui/material";
 import { NumericFormat } from "react-number-format";
 import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
 import Grid from "@mui/material/Grid";
+import AddIcon from "@mui/icons-material/Add";
 
 /* Modals para Agregar y Editar un/a estudiante */
 export const TeamModal = ({
@@ -151,7 +153,7 @@ export const TeamModal = ({
 
                     }
                     <InputLabel>Integrantes</InputLabel>
-                    {/* Integrante 1 */}                    
+                    {/* Integrantes */}                    
                     {item?.students?.map((student, index) => (
                       <Grid container spacing={2} sx={{ marginBottom: 2 }}>
                         <Grid item xs={3}>
@@ -170,7 +172,7 @@ export const TeamModal = ({
                                   newStudents[index] = { ...newStudents[index], id: parseInt(e.target.value) };
                                   setItem({ ...item, students: newStudents });
                                   }
-                            }
+                            }                            
                           />
                         </Grid>
                         <Grid item xs={9}>
@@ -180,15 +182,33 @@ export const TeamModal = ({
                             margin="normal"
                             label="Nombre y Apellido"
                             value={`${item.students?.[index]?.name || ""} ${item.students?.[index]?.last_name || ""}`}
-                            //required
-                            onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
+                            disabled
                           />
-                        </Grid>
-
-                        </Grid>
-
+                        </Grid>                        
+                      </Grid>
                     ))}
-                    <InputLabel> Fin probandooooo</InputLabel>                    
+
+                    <Grid container spacing={2} sx={{ marginBottom: 2 }}>
+                      {item?.students?.length < 4 && (
+                          <Grid item xs={12}>                            
+                            <Button
+                              fullWidth
+                              variant="outlined"
+                              aria-label="add"
+                              startIcon={<AddIcon/>}
+                              onClick={() => {
+                                const newStudents = [...item.students, { id: "", name: "", last_name: "" }];
+                                setItem({ ...item, students: newStudents });
+                              }}                              
+                            >
+
+                              Agregar Integrante
+                            </Button>
+
+                          </Grid>                          
+                      )} 
+                    </Grid>
+                    
                     {/*
                     // Aux:
                     // Pero no confiar, VER qué pasa con el orden de students, viene desde el back. [].

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -1,0 +1,264 @@
+import React from "react";
+import {
+    Button,
+    TextField,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    //
+    Select,
+    MenuItem,
+    InputLabel,
+    //
+    FormControl
+} from "@mui/material";
+import { NumericFormat } from "react-number-format";
+import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
+
+/* Modals para Agregar y Editar un/a estudiante */
+export const TeamModal = ({
+  //openAddModal, // bools para ver si se debe abrir cada modal
+  openEditModal,
+  //setOpenAddModal, // necesarias para cerrar los modals
+  setOpenEditModal,
+  //handleAddItem, // las acciones al clickear confirmar desde cada modal
+  handleEditItem,
+  originalEditedItemId, // para pasárselo a la función que habla con la api al confirmar, y su set para el handle
+  setOriginalEditedItemId,
+  item, // recibido del parent, y su set para flushearlo al salir
+  setParentItem,
+  topics,
+  tutors
+  
+}) => {
+
+      // Creo los estados, gestiono handle open, y obtengo los handle close.
+      const {
+        newItem,
+        setNewItem,
+        editedItem,
+        setEditedItem,
+        handleCloseAddModal,
+        handleCloseEditModal
+      } = useOpenCloseStateModalLogic({
+          openEditModal: openEditModal,
+          item: item,
+          setOpenAddModal: setOpenEditModal, // AUXXXX
+          setOpenEditModal: setOpenEditModal,
+          setOriginalEditedItemId: setOriginalEditedItemId,
+          setParentItem: setParentItem
+      });
+
+      /////// Modals ///////
+      // Aux: este modal va a ser el de editar directamente, y no existirá por ahora Add acá.
+      // Conservo la estructura solo x comodidad / analogía con otros archivos de modals. Ver dsp []
+      const innerActionTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
+        return (
+          <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
+            <DialogTitle
+              sx={{
+                fontWeight: "bold",
+                textAlign: "center",
+                backgroundColor: "#f5f5f5",
+                color: "#333",
+                padding: "16px 24px",
+              }}
+            >
+              {TitleText} Equipo
+            </DialogTitle>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault(); // previene el reload del form
+                handleConfirmAction(item, setItem, handleCloseModal);
+              }}
+            >
+              <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
+              <NumericFormat
+                  fullWidth
+                  allowNegative={false}
+                  customInput={TextField}
+                  variant="outlined"
+                  autoFocus
+                  margin="normal"
+                  label="Equipo número"
+                  value={item["id"] || ""}
+                  required
+                  onChange={(e) =>
+                    setItem({ ...item, id: parseInt(e.target.value) })
+                  }
+                  disabled
+                />
+                {/* Campos editables */}
+                {/* Integrantes */}
+                <NumericFormat
+                  fullWidth
+                  allowNegative={false}
+                  customInput={TextField}
+                  variant="outlined"
+                  autoFocus
+                  margin="normal"
+                  label="Padrón integrante 1"
+                  value={item && item["students"] && item["students"][0] || ""}
+                  required
+                  onChange={(e) =>
+                    setItem({ ...item, student_id_1: parseInt(e.target.value) })
+                  }
+                  disabled={disableEditId}
+                />
+                <NumericFormat
+                  fullWidth
+                  allowNegative={false}
+                  customInput={TextField}
+                  variant="outlined"
+                  autoFocus
+                  margin="normal"
+                  label="Padrón integrante 2"
+                  value={item["students"][1] || ""}
+                  required
+                  onChange={(e) =>
+                    setItem({ ...item, student_id_2: parseInt(e.target.value) })
+                  }
+                  disabled={disableEditId}
+                />
+                <NumericFormat
+                  fullWidth
+                  allowNegative={false}
+                  customInput={TextField}
+                  variant="outlined"
+                  autoFocus
+                  margin="normal"
+                  label="Padrón integrante 3"
+                  value={item["students"][2] || ""}
+                  required
+                  onChange={(e) =>
+                    setItem({ ...item, student_id_3: parseInt(e.target.value) })
+                  }
+                  disabled={disableEditId}
+                />
+                <NumericFormat
+                  fullWidth
+                  allowNegative={false}
+                  customInput={TextField}
+                  variant="outlined"
+                  autoFocus
+                  margin="normal"
+                  label="Padrón integrante 4"
+                  value={item["students"][3] || ""}
+                  required
+                  onChange={(e) =>
+                    setItem({ ...item, student_id_4: parseInt(e.target.value) })
+                  }
+                  disabled={disableEditId}
+                />
+
+                {/* Tema y tutor */} {/* aux: los copypasteo de StudentForm */}
+                <FormControl fullWidth variant="outlined" margin="normal">
+                    <InputLabel>Tema 2</InputLabel>
+                    <Select
+                      name="topic2"
+                      value={item.topic?.name || "Sin asignar!!! VERRRRRR"}
+                      onChange={(e) =>
+                        setItem({ ...item, topic_id: 1 }) 
+                      }
+                      label="Tema"
+                      required
+                    >
+                      {topics.map((topic) => (
+                        <MenuItem
+                          key={topic.name}
+                          value={topic.name}
+                        >
+                          {topic.name}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                
+                <InputLabel margin="normal">Seleccionar tutor</InputLabel>
+                <Select
+                  margin="normal"
+                  value={item.tutor_period_id || "VERRRRR cómo mostrar su NyA"}
+                  label="Email de tutor"
+                  onChange={(e) =>
+                    setItem({ ...item, tutor_email: "a@b.c" })
+                  }
+                  required
+                  fullWidth
+                >
+                  <MenuItem key="" value="" disabled>
+                    Seleccionar tutor
+                  </MenuItem>
+                  {tutors.map((tutor) => (
+                    <MenuItem key={tutor.id} value={tutor.email}>
+                      {tutor.email}
+                    </MenuItem>
+                  ))}
+                </Select>
+
+
+
+                {/* Las tres preferencias, no editables */}
+                <TextField
+                  variant="outlined"
+                  fullWidth
+                  margin="normal"
+                  label="Preferencia 1"
+                  value={item["name"] || ""}
+                  required
+                  onChange={(e) => setItem({ ...item, name: e.target.value })}
+
+                />
+                <TextField
+                  variant="outlined"
+                  fullWidth
+                  margin="normal"
+                  label="Preferencia 2"
+                  value={item["last_name"] || ""}
+                  required
+                  onChange={(e) =>
+                    setItem({ ...item, last_name: e.target.value })
+                  }
+                />
+                <TextField
+                  type="email"
+                  fullWidth
+                  margin="normal"
+                  label="Preferencia 3"
+                  variant="outlined"
+                  value={item["email"] || ""}
+                  onChange={(e) =>
+                    setItem({ ...item, email: e.target.value })
+                  }
+                  required
+                />
+              </DialogContent>
+
+              <DialogActions>
+                <Button onClick={handleCloseModal} variant="outlined" color="error">
+                  Cancelar
+                </Button>
+                <Button type="submit" variant="contained" color="primary">
+                  {ConfirmButtonText}
+                </Button>
+              </DialogActions>
+            </form>
+          </Dialog>
+        )
+      };
+
+      const addTeamModal = () => {
+        // To-Doreturn innerActionStudentModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Agregar")
+      }
+    
+      const editTeamModal = () => {
+        return innerActionTeamModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
+      }
+
+  return (
+    <>
+      {/*addTeamModal()*/};
+      {editTeamModal()};
+    </>
+  )
+}

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -17,6 +17,7 @@ import {
 } from "@mui/material";
 import Grid from "@mui/material/Grid";
 import AddIcon from "@mui/icons-material/Add";
+const CLEARSTRING = "Eliminar integrante";
 
 /* Modals para Editar un equipo y Confirmar la edición en caso de conflicto */
 export const TeamModal = ({
@@ -122,12 +123,13 @@ export const TeamModal = ({
                     {item?.students?.map((student, index) => (
                                         
                       <Grid container spacing={2} sx={{ marginBottom: 2 }}>
-                        <Grid item xs={12}>                          
+                        <Grid item xs={12}>
                           <Autocomplete
                             disablePortal
                             options={students || []}
                             getOptionLabel={(option) => option.id? `${option.id} - ${option.name} ${option.last_name}` : ""} // cómo mostrar el texto
-                            sx={{ width: '100%' }}                            
+                            sx={{ width: '100%' }}
+                            clearText={CLEARSTRING}
                             renderInput={(students) => <TextField {...students}
                                                           label=""/>}
                             onChange={(event, newValue) => {

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -50,6 +50,28 @@ export const TeamModal = ({
           setParentItem: setParentItem
       });
 
+      // AUX: ESTAS FUNCIONES DEBERÍAN SER IMPORTABLES []
+      // Función para obtener el nombre del topic por su id
+      const getTopicNameById = (id) => {
+        const topic = topics.find((t) => t.id === id);
+        return topic ? topic.name : ""; // Si no encuentra el topic, mostrar 'Desconocido'
+      };
+      // Función para obtener el nombre del tutor por su id
+        const getTutorNameById = (id, periodId) => {
+            const tutor = tutors.find(
+            (t) =>
+                t.tutor_periods &&
+                t.tutor_periods.some((tp) => tp.period_id === periodId && tp.id === id)
+            );
+            return tutor ? tutor.name + " " + tutor.last_name : "Sin asignar"; // Si no encuentra el tutor, mostrar 'Sin asignar'
+        };
+    // AUX
+    const getTopicById = (id) => {
+        const topic = topics.find((t) => t.id === id);
+        return topic ? topic : ""; // Si no encuentra el topic, mostrar 'Desconocido'
+      };
+
+
       /////// Modals ///////
       // Aux: este modal va a ser el de editar directamente, y no existirá por ahora Add acá.
       // Conservo la estructura solo x comodidad / analogía con otros archivos de modals. Ver dsp []
@@ -104,7 +126,6 @@ export const TeamModal = ({
                   onChange={(e) =>
                     setItem({ ...item, student_id_1: parseInt(e.target.value) })
                   }
-                  disabled={disableEditId}
                 />
                 <NumericFormat
                   fullWidth
@@ -119,7 +140,6 @@ export const TeamModal = ({
                   onChange={(e) =>
                     setItem({ ...item, student_id_2: parseInt(e.target.value) })
                   }
-                  disabled={disableEditId}
                 />
                 <NumericFormat
                   fullWidth
@@ -134,7 +154,6 @@ export const TeamModal = ({
                   onChange={(e) =>
                     setItem({ ...item, student_id_3: parseInt(e.target.value) })
                   }
-                  disabled={disableEditId}
                 />
                 <NumericFormat
                   fullWidth
@@ -149,25 +168,23 @@ export const TeamModal = ({
                   onChange={(e) =>
                     setItem({ ...item, student_id_4: parseInt(e.target.value) })
                   }
-                  disabled={disableEditId}
                 />
 
                 {/* Tema y tutor */} {/* aux: los copypasteo de StudentForm */}
                 <FormControl fullWidth variant="outlined" margin="normal">
-                    <InputLabel>Tema 2</InputLabel>
+                    <InputLabel>Tema</InputLabel>
                     <Select
-                      name="topic2"
-                      value={item.topic?.name || "Sin asignar!!! VERRRRRR"}
+                      value={item.topic?.id || "Sin asignar!!! VERRRRRR _acá no es donde se muestra"}
                       onChange={(e) =>
-                        setItem({ ...item, topic_id: item.topic?.id }) 
+                        setItem({ ...item, topic: getTopicById(e.target.value) })
                       }
                       label="Tema"
                       required
                     >
                       {topics.map((topic) => (
                         <MenuItem
-                          key={topic.name}
-                          value={topic.name}
+                          key={topic.id}
+                          value={topic.id}
                         >
                           {topic.name}
                         </MenuItem>
@@ -178,10 +195,10 @@ export const TeamModal = ({
                 <InputLabel margin="normal">Seleccionar tutor</InputLabel>
                 <Select
                   margin="normal"
-                  value={item.tutor_period_id || "VERRRRR cómo mostrar su NyA"}
-                  label="Email de tutor"
+                  value={item.tutor_email || "VERRRRR cómo mostrar su NyA"}
+                  label="Tutor"
                   onChange={(e) =>
-                    setItem({ ...item, tutor_email: "a@b.c" })
+                    setItem({ ...item, tutor_email: e.target.value })
                   }
                   required
                   fullWidth
@@ -190,8 +207,8 @@ export const TeamModal = ({
                     Seleccionar tutor
                   </MenuItem>
                   {tutors.map((tutor) => (
-                    <MenuItem key={tutor.id} value={tutor.email}>
-                      {tutor.email}
+                    <MenuItem key={tutor.email} value={tutor.email}>
+                      {getTutorNameById(tutor.email)}
                     </MenuItem>
                   ))}
                 </Select>
@@ -204,33 +221,30 @@ export const TeamModal = ({
                   fullWidth
                   margin="normal"
                   label="Preferencia 1"
-                  value={item["name"] || ""}
-                  required
-                  onChange={(e) => setItem({ ...item, name: e.target.value })}
-
+                  value={item?.preferred_topics?.[0]
+                    ? getTopicNameById(item.preferred_topics[0])
+                    : ""}
+                  disabled
                 />
                 <TextField
                   variant="outlined"
                   fullWidth
                   margin="normal"
                   label="Preferencia 2"
-                  value={item["last_name"] || ""}
-                  required
-                  onChange={(e) =>
-                    setItem({ ...item, last_name: e.target.value })
-                  }
+                  value={item?.preferred_topics?.[1]
+                    ? getTopicNameById(item.preferred_topics[1])
+                    : ""}
+                  disabled
                 />
                 <TextField
-                  type="email"
                   fullWidth
                   margin="normal"
                   label="Preferencia 3"
                   variant="outlined"
-                  value={item["email"] || ""}
-                  onChange={(e) =>
-                    setItem({ ...item, email: e.target.value })
-                  }
-                  required
+                  value={item?.preferred_topics?.[2]
+                    ? getTopicNameById(item.preferred_topics[2])
+                    : ""}
+                  disabled
                 />
               </DialogContent>
 

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -147,7 +147,6 @@ export const TeamModal = ({
                   margin="normal"
                   label="Padrón integrante 2"
                   value={item && item["students"] && item["students"][1] && item["students"][1]["id"] || ""}
-                  required
                   onChange={(e) =>
                     setItem({ ...item, student_id_2: parseInt(e.target.value) })
                   }
@@ -161,7 +160,6 @@ export const TeamModal = ({
                   margin="normal"
                   label="Padrón integrante 3"
                   value={item && item["students"] && item["students"][2] && item["students"][2]["id"] || ""}
-                  required
                   onChange={(e) =>
                     setItem({ ...item, student_id_3: parseInt(e.target.value) })
                   }
@@ -175,7 +173,6 @@ export const TeamModal = ({
                   margin="normal"
                   label="Padrón integrante 4"
                   value={item && item["students"] && item["students"][3] && item["students"][3]["id"] || ""}
-                  required
                   onChange={(e) =>
                     setItem({ ...item, student_id_4: parseInt(e.target.value) })
                   }

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -19,23 +19,22 @@ import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
 import Grid from "@mui/material/Grid";
 import AddIcon from "@mui/icons-material/Add";
 
-/* Modals para Agregar y Editar un/a estudiante */
-// To-Do revisar estas props, alguna(s) sobra(n).
+/* Modals para Editar un equipo y Confirmar la edición en caso de conflicto */
 export const TeamModal = ({
-  openAddModal, // bools para ver si se debe abrir cada modal
-  openEditModal,
-  setOpenAddModal, // necesarias para cerrar los modals
-  setOpenEditModal,
-  handleAddItem, // las acciones al clickear confirmar desde cada modal
-  handleEditItem,
+  openEditModal, // bools para ver si se debe abrir cada modal
+  openConfirmModal,
+  setOpenEditModal, // necesarias para cerrar los modals
+  setOpenConfirmModal,
+  handleEditItem, // las acciones al clickear confirmar desde cada modal
+  handleConfirm,
   item, // recibido del parent, y su set para flushearlo al salir
   setParentItem,
   conflictMsg, // para pasarle el msg de la response del back al modal de conflicto, y su set
   setConflictMsg,
-  topics,
+  topics, // para buscar su email etc a partir de otros datos
   tutors,
   students,
-  periodId
+  periodId // para identificar el dato correcto en esas búsquedas
   
 }) => {
 
@@ -281,7 +280,7 @@ export const TeamModal = ({
       };
         
       const handleCloseConfirmModal = () => {
-        setOpenAddModal(false);
+        setOpenConfirmModal(false);
         //setParentItem(false); // este item
         setConflictMsg([]);        
       };
@@ -303,11 +302,11 @@ export const TeamModal = ({
       };
       
       const confirmEditOnConflictTeamModal = () => {
-        //return innerConfirmEditOnConflictModal(openAddModal, handleCloseBothModals, message, handleAddItem, editedItem, setEditedItem, "", "Confirmar")
-        //return innerConfirmEditOnConflictModal(openAddModal, handleCloseAddModal, message, handleAddItem, editedItem, setEditedItem, "", "Confirmar") // cierra el de abajo y no éste
-        console.log("--- VIENDO DESDE ADENTRO OTRA VEZ, EL BOOL: ",openAddModal);
-        //return innerConfirmEditOnConflictModal(openAddModal, handleCloseConfirmModal, handleCloseEditModal, message, handleAddItem, editedItem, setEditedItem, "", "Confirmar") // da error en inglés de que studentsInput es undefined, xq editedItem se flusheó
-        return innerConfirmEditOnConflictModal(openAddModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleAddItem, editedItem, setEditedItem, "", "Confirmar")
+        //return innerConfirmEditOnConflictModal(openConfirmModal, handleCloseBothModals, message, handleConfirm, editedItem, setEditedItem, "", "Confirmar")
+        //return innerConfirmEditOnConflictModal(openConfirmModal, handleCloseAddModal, message, handleConfirm, editedItem, setEditedItem, "", "Confirmar") // cierra el de abajo y no éste
+        console.log("--- VIENDO DESDE ADENTRO OTRA VEZ, EL BOOL: ",openConfirmModal);
+        //return innerConfirmEditOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModal, message, handleConfirm, editedItem, setEditedItem, "", "Confirmar") // da error en inglés de que studentsInput es undefined, xq editedItem se flusheó
+        return innerConfirmEditOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleConfirm, editedItem, setEditedItem, "", "Confirmar")
       }
       
       const innerConfirmEditOnConflictModal = (bool, handleCloseModal, handleCloseEditModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -11,7 +11,8 @@ import {
     MenuItem,
     InputLabel,
     //
-    FormControl
+    FormControl,
+    Typography
 } from "@mui/material";
 import { NumericFormat } from "react-number-format";
 import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
@@ -128,38 +129,47 @@ export const TeamModal = ({
                 {/* Campos editables */}
                 <Grid container spacing={2}>
                 {/* Columna izquierda */}
-                  <Grid item xs={12} md={6}>
+                  <Grid item xs={6} md={6}>
                     {/* Integrantes */}
-                    
-                    <NumericFormat
-                      //fullWidth
-                      allowNegative={false}
-                      customInput={TextField}
-                      variant="outlined"
-                      autoFocus
-                      margin="normal"
-                      label="Padrón integrante 1"
-                      value={item?.students?.[0].id || ""}
-                      required
-                      onChange={(e) =>
-                        {const newStudents = [...item.students];
-                            newStudents[0] = { ...newStudents[0], id: parseInt(e.target.value) };
-                            setItem({ ...item, students: newStudents });
-                            }
-                      }
-                    />
-                    <TextField
-                      variant="outlined"
-                      //fullWidth
-                      margin="normal"
-                      label="Nombre"
-                      value={item?.students?.[0].name || ""}
-                      required
-                      onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
-                    />
+                    <Typography variant="h6" gutterBottom>
+                      Integrantes
+                    </Typography>
+                    {/* Integrante 1 */}
+                    <Grid container spacing={2} sx={{ marginBottom: 2 }}>
+                      <Grid item xs={2}>
+                        <NumericFormat
+                          //fullWidth
+                          allowNegative={false}
+                          customInput={TextField}
+                          variant="outlined"
+                          autoFocus
+                          margin="normal"
+                          label="Padrón"
+                          value={item?.students?.[0].id || ""}
+                          required
+                          onChange={(e) =>
+                            {const newStudents = [...item.students];
+                                newStudents[0] = { ...newStudents[0], id: parseInt(e.target.value) };
+                                setItem({ ...item, students: newStudents });
+                                }
+                          }
+                        />
+                      </Grid>
+                      <Grid item xs={10}>
+                        <TextField
+                          variant="outlined"
+                          //fullWidth
+                          margin="normal"
+                          label="Nombre"
+                          value={`${item.students?.[0]?.name || ""} ${item.students?.[0]?.last_name || ""}`}
+                          required
+                          onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
+                        />
+                      </Grid>
 
+                    </Grid>
 
-
+                    {/* Integrante 2 - generalizar */}
                     <NumericFormat
                       //fullWidth
                       allowNegative={false}
@@ -177,7 +187,7 @@ export const TeamModal = ({
                       }
                     />
                     <NumericFormat
-                      //fullWidth
+                      fullWidth
                       allowNegative={false}
                       customInput={TextField}
                       variant="outlined"
@@ -193,7 +203,7 @@ export const TeamModal = ({
                       }
                     />
                     <NumericFormat
-                      //fullWidth
+                      fullWidth
                       allowNegative={false}
                       customInput={TextField}
                       variant="outlined"
@@ -214,7 +224,7 @@ export const TeamModal = ({
                   </Grid>
 
                   {/* Columna derecha */}
-                  <Grid item xs={12} md={6}>
+                  <Grid item xs={6} md={6}>
 
                   {/* Tema y tutor */} {/* aux: los copypasteo de StudentForm */}
                   <FormControl fullWidth variant="outlined" margin="normal">

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -151,146 +151,44 @@ export const TeamModal = ({
 
                     }
                     <InputLabel>Integrantes</InputLabel>
-                    {/* Integrante 1 */}
-                    <Grid container spacing={2} sx={{ marginBottom: 2 }}>
-                      <Grid item xs={3}>
-                        <NumericFormat
-                          //fullWidth
-                          allowNegative={false}
-                          customInput={TextField}
-                          variant="outlined"
-                          autoFocus
-                          margin="normal"
-                          label="Padrón"
-                          value={item?.students?.[0].id || ""}
-                          //required
-                          onChange={(e) =>
-                            {const newStudents = [...item.students];
-                                newStudents[0] = { ...newStudents[0], id: parseInt(e.target.value) };
-                                setItem({ ...item, students: newStudents });
-                                }
-                          }
-                        />
-                      </Grid>
-                      <Grid item xs={9}>
-                        <TextField
-                          variant="outlined"
-                          fullWidth
-                          margin="normal"
-                          label="Nombre y Apellido"
-                          value={`${item.students?.[0]?.name || ""} ${item.students?.[0]?.last_name || ""}`}
-                          //required
-                          onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
-                        />
-                      </Grid>
+                    {/* Integrante 1 */}                    
+                    {item?.students?.map((student, index) => (
+                      <Grid container spacing={2} sx={{ marginBottom: 2 }}>
+                        <Grid item xs={3}>
+                          <NumericFormat
+                            //fullWidth
+                            allowNegative={false}
+                            customInput={TextField}
+                            variant="outlined"
+                            autoFocus={index===0}
+                            margin="normal"
+                            label="Padrón"
+                            value={item?.students?.[index].id || ""}
+                            //required
+                            onChange={(e) =>
+                              {const newStudents = [...item.students];
+                                  newStudents[index] = { ...newStudents[index], id: parseInt(e.target.value) };
+                                  setItem({ ...item, students: newStudents });
+                                  }
+                            }
+                          />
+                        </Grid>
+                        <Grid item xs={9}>
+                          <TextField
+                            variant="outlined"
+                            fullWidth
+                            margin="normal"
+                            label="Nombre y Apellido"
+                            value={`${item.students?.[index]?.name || ""} ${item.students?.[index]?.last_name || ""}`}
+                            //required
+                            onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
+                          />
+                        </Grid>
 
-                    </Grid>
+                        </Grid>
 
-                    {/* Integrante 2 */}
-                    <Grid container spacing={2} sx={{ marginBottom: 2 }}>
-                      <Grid item xs={3}>
-                        <NumericFormat
-                          //fullWidth
-                          allowNegative={false}
-                          customInput={TextField}
-                          variant="outlined"
-                          autoFocus
-                          margin="normal"
-                          label="Padrón"
-                          value={item?.students?.[1].id || ""}
-                          //required
-                          onChange={(e) =>
-                            {const newStudents = [...item.students];
-                                newStudents[1] = { ...newStudents[1], id: parseInt(e.target.value) };
-                                setItem({ ...item, students: newStudents });
-                                }
-                          }
-                        />
-                      </Grid>
-                      <Grid item xs={9}>
-                        <TextField
-                          variant="outlined"
-                          fullWidth
-                          margin="normal"
-                          label="Nombre y Apellido"
-                          value={`${item.students?.[1]?.name || ""} ${item.students?.[1]?.last_name || ""}`}
-                          //required
-                          onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
-                        />
-                      </Grid>
-
-                    </Grid>
-
-                    {/* Integrante 3 */}
-                    <Grid container spacing={2} sx={{ marginBottom: 2 }}>
-                      <Grid item xs={3}>
-                        <NumericFormat
-                          //fullWidth
-                          allowNegative={false}
-                          customInput={TextField}
-                          variant="outlined"
-                          autoFocus
-                          margin="normal"
-                          label="Padrón"
-                          value={item?.students?.[2].id || ""}
-                          //required
-                          onChange={(e) =>
-                            {const newStudents = [...item.students];
-                                newStudents[2] = { ...newStudents[2], id: parseInt(e.target.value) };
-                                setItem({ ...item, students: newStudents });
-                                }
-                          }
-                        />
-                      </Grid>
-                      <Grid item xs={9}>
-                        <TextField
-                          variant="outlined"
-                          fullWidth
-                          margin="normal"
-                          label="Nombre y Apellido"
-                          value={`${item.students?.[2]?.name || ""} ${item.students?.[2]?.last_name || ""}`}
-                          //required
-                          onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
-                        />
-                      </Grid>
-
-                    </Grid>
-
-                    {/* Integrante 4 */}
-                    <Grid container spacing={2} sx={{ marginBottom: 2 }}>
-                      <Grid item xs={3}>
-                        <NumericFormat
-                          //fullWidth
-                          allowNegative={false}
-                          customInput={TextField}
-                          variant="outlined"
-                          autoFocus
-                          margin="normal"
-                          label="Padrón"
-                          value={item?.students?.[3].id || ""}
-                          //required
-                          onChange={(e) =>
-                            {const newStudents = [...item.students];
-                                newStudents[3] = { ...newStudents[3], id: parseInt(e.target.value) };
-                                setItem({ ...item, students: newStudents });
-                                }
-                          }
-                        />
-                      </Grid>
-                      <Grid item xs={9}>
-                        <TextField
-                          variant="outlined"
-                          fullWidth
-                          margin="normal"
-                          label="Nombre y Apellido"
-                          value={`${item.students?.[3]?.name || ""} ${item.students?.[3]?.last_name || ""}`}
-                          //required
-                          onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
-                        />
-                      </Grid>
-
-                    </Grid>
-                    */
+                    ))}
+                    <InputLabel> Fin probandooooo</InputLabel>                    
                     {/*
                     // Aux:
                     // Pero no confiar, VER qué pasa con el orden de students, viene desde el back. [].

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
     Button,
     TextField,
@@ -40,6 +40,7 @@ export const TeamModal = ({
   
 }) => {
 
+      console.log("--- VIENDO DESDE ADENTRO, EL BOOL: ",openAddModal);
       // Creo los estados, gestiono handle open, y obtengo los handle close.
       const {
         newItem,
@@ -96,7 +97,7 @@ export const TeamModal = ({
       // Conservo la estructura solo x comodidad / analogía con otros archivos de modals. Ver dsp []
       const innerActionTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
         return (
-          <Dialog open={bool} onClose={handleCloseModal} maxWidth={false} fullWidth PaperProps={{
+          <Dialog open={bool} maxWidth={false} fullWidth PaperProps={{
             style: {
               height: "90vh",
               maxHeight: "90vh", // Limita la altura máxima para que no desborde
@@ -325,6 +326,31 @@ export const TeamModal = ({
       const editTeamModal = () => {
         return innerActionTeamModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
       }
+
+      const handleCloseBothModals = () => {
+        // "add" (confirm modal)
+        setNewItem({})
+        setOpenAddModal(false);
+        //setParentItem(false);
+
+        // edit
+        setEditedItem({})
+        setOpenEditModal(false);
+        setParentItem(false);
+      };
+      const handleCloseConfirmModal = () => {
+        console.log("--- HOLAAA, DESDE TEAM MODAL, BOOL:", openAddModal);
+        setNewItem({}); // a esto no lo uso en este caso, se puede borrar esta línea
+        setOpenAddModal(false);
+        //setParentItem(false); // este item
+        console.log("--- DESDE TEAM MODAL, CERRÉ SUPUESTAMENTE EL BOOL:", openAddModal);
+      };
+
+      const handleCloseEditModalWithoutFlushingEditedItem = () => {
+        //setEditedItem({})
+        setOpenEditModal(false);
+        setParentItem(false);
+      };
       
       const confirmEditOnConflictTeamModal = () => {
         // Aux: Tengo que crear el useState nuevo (bool open) desde afuera xq desde afuera lo voy a cerrar, y manejar eso
@@ -334,10 +360,14 @@ export const TeamModal = ({
         // Aux, tiene que ser obviamente un parámetro real y no esta cosa horrible (:
         const res = {"detail":["Estudiante 103944 - JOAQUIN EMANUEL HETREA ya se encuentra en equipo 135","Estudiante 99779 - JUAN IGNACIO KRISTAL ya se encuentra en equipo 148"]};
         const message = res.detail;
-        return innerConfirmEditOnConflictModal(openAddModal, handleCloseAddModal, message, handleAddItem, editedItem, setEditedItem, "", "Confirmar")
+        //return innerConfirmEditOnConflictModal(openAddModal, handleCloseBothModals, message, handleAddItem, editedItem, setEditedItem, "", "Confirmar")
+        //return innerConfirmEditOnConflictModal(openAddModal, handleCloseAddModal, message, handleAddItem, editedItem, setEditedItem, "", "Confirmar") // cierra el de abajo y no éste
+        console.log("--- VIENDO DESDE ADENTRO OTRA VEZ, EL BOOL: ",openAddModal);
+        //return innerConfirmEditOnConflictModal(openAddModal, handleCloseConfirmModal, handleCloseEditModal, message, handleAddItem, editedItem, setEditedItem, "", "Confirmar") // da error en inglés de que studentsInput es undefined, xq editedItem se flusheó
+        return innerConfirmEditOnConflictModal(openAddModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, message, handleAddItem, editedItem, setEditedItem, "", "Confirmar")
       }
       ////////////
-      const innerConfirmEditOnConflictModal = (bool, handleCloseModal, message, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {
+      const innerConfirmEditOnConflictModal = (bool, handleCloseModal, handleCloseEditModal, message, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth={false}>
             <DialogTitle
@@ -373,7 +403,7 @@ export const TeamModal = ({
                 <Button onClick={handleCloseModal} variant="outlined" color="error">
                   Cancelar
                 </Button>
-                <Button type="submit" variant="contained" color="primary">
+                <Button type="submit" onClick={handleCloseEditModal} variant="contained" color="primary">
                   {ConfirmButtonText}
                 </Button>
               </DialogActions>

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -159,7 +159,7 @@ export const TeamModal = ({
                           margin="normal"
                           label="Padrón"
                           value={item?.students?.[0].id || ""}
-                          required
+                          //required
                           onChange={(e) =>
                             {const newStudents = [...item.students];
                                 newStudents[0] = { ...newStudents[0], id: parseInt(e.target.value) };
@@ -175,15 +175,123 @@ export const TeamModal = ({
                           margin="normal"
                           label="Nombre y Apellido"
                           value={`${item.students?.[0]?.name || ""} ${item.students?.[0]?.last_name || ""}`}
-                          required
+                          //required
                           onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
                         />
                       </Grid>
 
                     </Grid>
 
+                    {/* Integrante 2 */}
+                    <Grid container spacing={2} sx={{ marginBottom: 2 }}>
+                      <Grid item xs={3}>
+                        <NumericFormat
+                          //fullWidth
+                          allowNegative={false}
+                          customInput={TextField}
+                          variant="outlined"
+                          autoFocus
+                          margin="normal"
+                          label="Padrón"
+                          value={item?.students?.[1].id || ""}
+                          //required
+                          onChange={(e) =>
+                            {const newStudents = [...item.students];
+                                newStudents[1] = { ...newStudents[1], id: parseInt(e.target.value) };
+                                setItem({ ...item, students: newStudents });
+                                }
+                          }
+                        />
+                      </Grid>
+                      <Grid item xs={9}>
+                        <TextField
+                          variant="outlined"
+                          fullWidth
+                          margin="normal"
+                          label="Nombre y Apellido"
+                          value={`${item.students?.[1]?.name || ""} ${item.students?.[1]?.last_name || ""}`}
+                          //required
+                          onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
+                        />
+                      </Grid>
+
+                    </Grid>
+
+                    {/* Integrante 3 */}
+                    <Grid container spacing={2} sx={{ marginBottom: 2 }}>
+                      <Grid item xs={3}>
+                        <NumericFormat
+                          //fullWidth
+                          allowNegative={false}
+                          customInput={TextField}
+                          variant="outlined"
+                          autoFocus
+                          margin="normal"
+                          label="Padrón"
+                          value={item?.students?.[2].id || ""}
+                          //required
+                          onChange={(e) =>
+                            {const newStudents = [...item.students];
+                                newStudents[2] = { ...newStudents[2], id: parseInt(e.target.value) };
+                                setItem({ ...item, students: newStudents });
+                                }
+                          }
+                        />
+                      </Grid>
+                      <Grid item xs={9}>
+                        <TextField
+                          variant="outlined"
+                          fullWidth
+                          margin="normal"
+                          label="Nombre y Apellido"
+                          value={`${item.students?.[2]?.name || ""} ${item.students?.[2]?.last_name || ""}`}
+                          //required
+                          onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
+                        />
+                      </Grid>
+
+                    </Grid>
+
+                    {/* Integrante 4 */}
+                    <Grid container spacing={2} sx={{ marginBottom: 2 }}>
+                      <Grid item xs={3}>
+                        <NumericFormat
+                          //fullWidth
+                          allowNegative={false}
+                          customInput={TextField}
+                          variant="outlined"
+                          autoFocus
+                          margin="normal"
+                          label="Padrón"
+                          value={item?.students?.[3].id || ""}
+                          //required
+                          onChange={(e) =>
+                            {const newStudents = [...item.students];
+                                newStudents[3] = { ...newStudents[3], id: parseInt(e.target.value) };
+                                setItem({ ...item, students: newStudents });
+                                }
+                          }
+                        />
+                      </Grid>
+                      <Grid item xs={9}>
+                        <TextField
+                          variant="outlined"
+                          fullWidth
+                          margin="normal"
+                          label="Nombre y Apellido"
+                          value={`${item.students?.[3]?.name || ""} ${item.students?.[3]?.last_name || ""}`}
+                          //required
+                          onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
+                        />
+                      </Grid>
+
+                    </Grid>
+
+                    {/*//////////////////////////////////
+                    */
+                    }
                     {/* Integrante 2 - generalizar */}
-                    <NumericFormat
+                    {/*<NumericFormat
                       //fullWidth
                       allowNegative={false}
                       customInput={TextField}
@@ -233,6 +341,7 @@ export const TeamModal = ({
                       // Aux:
                       // Pero no confiar, VER qué pasa con el orden de students, viene desde el back. [].
                     />
+                      */}
 
                   </Grid>
 

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -80,7 +80,7 @@ export const TeamModal = ({
     };
 
       /////// Modals ///////
-      // Este modal va a ser el de editar directamente, y no existirá Add acá.
+      // Este modal va a ser el de editar directamente (hay add en StudentForm).
       // Conservo la estructura solo x comodidad / analogía con otros archivos de modals.
       const innerEditTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
         return (
@@ -119,7 +119,7 @@ export const TeamModal = ({
                   <Grid item xs={6} md={6}>
                     
                     {/* Integrantes */}                    
-                    <InputLabel sx={{ mb: 2 }}>Integrantes</InputLabel> {/* mb = marginBottom */}
+                    <InputLabel sx={{ mb: 2 }}>Integrantes</InputLabel>
                     {item?.students?.map((student, index) => (
                                         
                       <Grid container spacing={2} sx={{ marginBottom: 2 }}>
@@ -177,7 +177,7 @@ export const TeamModal = ({
                   {/* Columna derecha */}
                   <Grid item xs={6} md={6}>
 
-                  {/* Tema y tutor */} {/* aux: los copypasteo de StudentForm */}
+                  {/* Tema y tutor */}
                   <InputLabel>Tema y Tutor/a</InputLabel>
                   <FormControl fullWidth variant="outlined" margin="normal">
                       <InputLabel>Tema</InputLabel>
@@ -291,12 +291,10 @@ export const TeamModal = ({
         
       const handleCloseConfirmModal = () => {
         setOpenConfirmModal(false);
-        //setParentItem(false); // este item
         setConflictMsg([]);        
       };
 
       const handleCloseEditModalWithoutFlushingEditedItem = () => {
-        //setEditedItem({})
         setOpenEditModal(false);
         setParentItem(false);
       };
@@ -315,8 +313,6 @@ export const TeamModal = ({
       const confirmEditOnConflictTeamModal = () => {
         // Usa el editedItem, por lo que en el medio, no se debe haber flusheado editedItem (ej hay que no cerrar (desde afuera) el modal anterior si hay conflicto)
         // Además, luego de Confirmar se necesita usar desde afuera al editedItem por lo que no hay que flushearlo desde acá sino afuera
-        console.log("--- VIENDO DESDE ADENTRO OTRA VEZ, EL BOOL: ",openConfirmModal);
-        //return innerConfirmEditOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModal, message, handleConfirm, editedItem, setEditedItem, "", "Confirmar") // da error en inglés de que studentsInput es undefined, xq editedItem se flusheó
         return innerConfirmEditOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleConfirm, editedItem, setEditedItem, "", "Confirmar")
       }
       
@@ -393,7 +389,6 @@ export const TeamModal = ({
 
   return (
     <>
-      {/*addTeamModal()*/}
       {editTeamModal()}
       {confirmEditOnConflictTeamModal()}
     </>

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -132,10 +132,13 @@ export const TeamModal = ({
                   autoFocus
                   margin="normal"
                   label="Padrón integrante 1"
-                  value={item && item["students"] && item["students"][0] && item["students"][0]["id"] || ""}
+                  value={item?.students?.[0].id || ""}
                   required
                   onChange={(e) =>
-                    setItem({ ...item, student_id_1: parseInt(e.target.value) })
+                    {const newStudents = [...item.students];
+                        newStudents[0] = { ...newStudents[0], id: parseInt(e.target.value) };
+                        setItem({ ...item, students: newStudents });
+                        }
                   }
                 />
                 <NumericFormat
@@ -146,9 +149,13 @@ export const TeamModal = ({
                   autoFocus
                   margin="normal"
                   label="Padrón integrante 2"
-                  value={item && item["students"] && item["students"][1] && item["students"][1]["id"] || ""}
+                  value={item?.students?.[1].id || ""}
                   onChange={(e) =>
-                    setItem({ ...item, student_id_2: parseInt(e.target.value) })
+                    //setItem({ ...item, item.students.[1].id: parseInt(e.target.value) })
+                    {const newStudents = [...item.students];
+                    newStudents[1] = { ...newStudents[1], id: parseInt(e.target.value) };
+                    setItem({ ...item, students: newStudents });
+                    }
                   }
                 />
                 <NumericFormat
@@ -159,9 +166,12 @@ export const TeamModal = ({
                   autoFocus
                   margin="normal"
                   label="Padrón integrante 3"
-                  value={item && item["students"] && item["students"][2] && item["students"][2]["id"] || ""}
+                  value={item?.students?.[2].id || ""}
                   onChange={(e) =>
-                    setItem({ ...item, student_id_3: parseInt(e.target.value) })
+                    {const newStudents = [...item.students];
+                        newStudents[2] = { ...newStudents[2], id: parseInt(e.target.value) };
+                        setItem({ ...item, students: newStudents });
+                    }
                   }
                 />
                 <NumericFormat
@@ -172,10 +182,15 @@ export const TeamModal = ({
                   autoFocus
                   margin="normal"
                   label="Padrón integrante 4"
-                  value={item && item["students"] && item["students"][3] && item["students"][3]["id"] || ""}
+                  value={item?.students?.[3].id || ""}
                   onChange={(e) =>
-                    setItem({ ...item, student_id_4: parseInt(e.target.value) })
+                    {const newStudents = [...item.students];
+                        newStudents[3] = { ...newStudents[3], id: parseInt(e.target.value) };
+                        setItem({ ...item, students: newStudents });
+                    }
                   }
+                  // Aux:
+                  // Pero no confiar, VER qué pasa con el orden de students, viene desde el back. [].
                 />
 
                 {/* Tema y tutor */} {/* aux: los copypasteo de StudentForm */}

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { useEffect, useState } from "react";
 import {
     Button,
     TextField,
@@ -27,8 +28,6 @@ export const TeamModal = ({
   setOpenEditModal,
   handleAddItem, // las acciones al clickear confirmar desde cada modal
   handleEditItem,
-  originalEditedItemId, // para pasárselo a la función que habla con la api al confirmar, y su set para el handle
-  setOriginalEditedItemId,
   item, // recibido del parent, y su set para flushearlo al salir
   setParentItem,
   conflictMsg, // para pasarle el msg de la response del back al modal de conflicto, y su set
@@ -39,23 +38,15 @@ export const TeamModal = ({
   periodId
   
 }) => {
-      // Creo los estados, gestiono handle open, y obtengo los handle close.
-      // Aux: no se usaría esto, solo traer el const del editedItem para acá y lo demás no es relevante.
-      const {
-        newItem,
-        setNewItem,
-        editedItem,
-        setEditedItem,
-        handleCloseAddModal,
-        handleCloseEditModal
-      } = useOpenCloseStateModalLogic({
-          openEditModal: openEditModal,
-          item: item,
-          setOpenAddModal: setOpenEditModal, // AUXXXX
-          setOpenEditModal: setOpenEditModal,
-          setOriginalEditedItemId: setOriginalEditedItemId,
-          setParentItem: setParentItem
-      });
+
+      const [editedItem, setEditedItem] = useState({});          
+      // Esto hace de handle open edit
+      useEffect(() => {
+        if (!openEditModal) return;
+
+        setEditedItem(item); 
+
+      }, [openEditModal, item]);      
 
       // AUX: ESTAS FUNCIONES DEBERÍAN SER IMPORTABLES []
       // Función para obtener el nombre del topic por su id
@@ -288,17 +279,22 @@ export const TeamModal = ({
           </Dialog>
         )
       };
-    
-      const editTeamModal = () => {
-        return innerActionTeamModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
-      }
-
+        
       const handleCloseConfirmModal = () => {
-        setNewItem({}); // a esto no lo uso en este caso, se puede borrar esta línea
         setOpenAddModal(false);
         //setParentItem(false); // este item
         setConflictMsg([]);        
       };
+
+      const handleCloseEditModal = () => {
+        setEditedItem({})
+        setOpenEditModal(false);
+        setParentItem(false);
+      };
+      
+      const editTeamModal = () => {
+        return innerActionTeamModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
+      }
 
       const handleCloseEditModalWithoutFlushingEditedItem = () => {
         //setEditedItem({})

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -15,6 +15,7 @@ import {
 } from "@mui/material";
 import { NumericFormat } from "react-number-format";
 import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
+import Grid from "@mui/material/Grid";
 
 /* Modals para Agregar y Editar un/a estudiante */
 export const TeamModal = ({
@@ -90,7 +91,7 @@ export const TeamModal = ({
       // Conservo la estructura solo x comodidad / analogía con otros archivos de modals. Ver dsp []
       const innerActionTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
         return (
-          <Dialog open={bool} onClose={handleCloseModal} maxWidth="sm" fullWidth>
+          <Dialog open={bool} onClose={handleCloseModal} maxWidth={false} fullWidth>
             <DialogTitle
               sx={{
                 fontWeight: "bold",
@@ -125,160 +126,184 @@ export const TeamModal = ({
                   disabled
                 />
                 {/* Campos editables */}
-                {/* Integrantes */}
-                <NumericFormat
-                  fullWidth
-                  allowNegative={false}
-                  customInput={TextField}
-                  variant="outlined"
-                  autoFocus
-                  margin="normal"
-                  label="Padrón integrante 1"
-                  value={item?.students?.[0].id || ""}
-                  required
-                  onChange={(e) =>
-                    {const newStudents = [...item.students];
-                        newStudents[0] = { ...newStudents[0], id: parseInt(e.target.value) };
+                <Grid container spacing={2}>
+                {/* Columna izquierda */}
+                  <Grid item xs={12} md={6}>
+                    {/* Integrantes */}
+                    
+                    <NumericFormat
+                      //fullWidth
+                      allowNegative={false}
+                      customInput={TextField}
+                      variant="outlined"
+                      autoFocus
+                      margin="normal"
+                      label="Padrón integrante 1"
+                      value={item?.students?.[0].id || ""}
+                      required
+                      onChange={(e) =>
+                        {const newStudents = [...item.students];
+                            newStudents[0] = { ...newStudents[0], id: parseInt(e.target.value) };
+                            setItem({ ...item, students: newStudents });
+                            }
+                      }
+                    />
+                    <TextField
+                      variant="outlined"
+                      //fullWidth
+                      margin="normal"
+                      label="Nombre"
+                      value={item?.students?.[0].name || ""}
+                      required
+                      onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
+                    />
+
+
+
+                    <NumericFormat
+                      //fullWidth
+                      allowNegative={false}
+                      customInput={TextField}
+                      variant="outlined"
+                      autoFocus
+                      margin="normal"
+                      label="Padrón integrante 2"
+                      value={item?.students?.[1].id || ""}
+                      onChange={(e) =>
+                        {const newStudents = [...item.students];
+                        newStudents[1] = { ...newStudents[1], id: parseInt(e.target.value) };
                         setItem({ ...item, students: newStudents });
                         }
-                  }
-                />
-                <NumericFormat
-                  fullWidth
-                  allowNegative={false}
-                  customInput={TextField}
-                  variant="outlined"
-                  autoFocus
-                  margin="normal"
-                  label="Padrón integrante 2"
-                  value={item?.students?.[1].id || ""}
-                  onChange={(e) =>
-                    {const newStudents = [...item.students];
-                    newStudents[1] = { ...newStudents[1], id: parseInt(e.target.value) };
-                    setItem({ ...item, students: newStudents });
-                    }
-                  }
-                />
-                <NumericFormat
-                  fullWidth
-                  allowNegative={false}
-                  customInput={TextField}
-                  variant="outlined"
-                  autoFocus
-                  margin="normal"
-                  label="Padrón integrante 3"
-                  value={item?.students?.[2].id || ""}
-                  onChange={(e) =>
-                    {const newStudents = [...item.students];
-                        newStudents[2] = { ...newStudents[2], id: parseInt(e.target.value) };
-                        setItem({ ...item, students: newStudents });
-                    }
-                  }
-                />
-                <NumericFormat
-                  fullWidth
-                  allowNegative={false}
-                  customInput={TextField}
-                  variant="outlined"
-                  autoFocus
-                  margin="normal"
-                  label="Padrón integrante 4"
-                  value={item?.students?.[3].id || ""}
-                  onChange={(e) =>
-                    {const newStudents = [...item.students];
-                        newStudents[3] = { ...newStudents[3], id: parseInt(e.target.value) };
-                        setItem({ ...item, students: newStudents });
-                    }
-                  }
-                  // Aux:
-                  // Pero no confiar, VER qué pasa con el orden de students, viene desde el back. [].
-                />
-
-                {/* Tema y tutor */} {/* aux: los copypasteo de StudentForm */}
-                <FormControl fullWidth variant="outlined" margin="normal">
-                    <InputLabel>Tema</InputLabel>
-                    <Select
-                      value={item.topic?.id || ""}
-                      onChange={(e) =>
-                        setItem({ ...item, topic: getTopicById(e.target.value) })
                       }
-                      label="Tema"
+                    />
+                    <NumericFormat
+                      //fullWidth
+                      allowNegative={false}
+                      customInput={TextField}
+                      variant="outlined"
+                      autoFocus
+                      margin="normal"
+                      label="Padrón integrante 3"
+                      value={item?.students?.[2].id || ""}
+                      onChange={(e) =>
+                        {const newStudents = [...item.students];
+                            newStudents[2] = { ...newStudents[2], id: parseInt(e.target.value) };
+                            setItem({ ...item, students: newStudents });
+                        }
+                      }
+                    />
+                    <NumericFormat
+                      //fullWidth
+                      allowNegative={false}
+                      customInput={TextField}
+                      variant="outlined"
+                      autoFocus
+                      margin="normal"
+                      label="Padrón integrante 4"
+                      value={item?.students?.[3].id || ""}
+                      onChange={(e) =>
+                        {const newStudents = [...item.students];
+                            newStudents[3] = { ...newStudents[3], id: parseInt(e.target.value) };
+                            setItem({ ...item, students: newStudents });
+                        }
+                      }
+                      // Aux:
+                      // Pero no confiar, VER qué pasa con el orden de students, viene desde el back. [].
+                    />
+
+                  </Grid>
+
+                  {/* Columna derecha */}
+                  <Grid item xs={12} md={6}>
+
+                  {/* Tema y tutor */} {/* aux: los copypasteo de StudentForm */}
+                  <FormControl fullWidth variant="outlined" margin="normal">
+                      <InputLabel>Tema</InputLabel>
+                      <Select
+                        value={item.topic?.id || ""}
+                        onChange={(e) =>
+                          setItem({ ...item, topic: getTopicById(e.target.value) })
+                        }
+                        label="Tema"
+                        required
+                      >
+                        {topics.map((topic) => (
+                          <MenuItem
+                            key={topic.id}
+                            value={topic.id}
+                          >
+                            {topic.name}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  
+                  <FormControl fullWidth variant="outlined" margin="normal">
+                    {<InputLabel margin="normal">Tutor/a</InputLabel>
+                    }
+                    <Select
+                      margin="normal"
+                      value={item.tutor_period_id || ""}
+                      label="Tutor"
+                      onChange={(e) =>
+                        setItem({ ...item, tutor_period_id: e.target.value })
+                      }
                       required
+                      fullWidth
                     >
-                      {topics.map((topic) => (
-                        <MenuItem
-                          key={topic.id}
-                          value={topic.id}
-                        >
-                          {topic.name}
-                        </MenuItem>
-                      ))}
+                      <MenuItem key="" value="" disabled>
+                        Seleccionar tutor
+                      </MenuItem>
+                      {tutors.map((tutor) => {
+                        const tp = tutor.tutor_periods.find((tp) => tp.period_id === periodId);
+                        if (!tp) return null; // ignorar si no hay uno del period pedido
+
+                        return (
+                            <MenuItem key={tp.id} value={tp.id}>
+                            {tutor.name} {tutor.last_name}
+                            </MenuItem>
+                        );
+                        })}
+
                     </Select>
                   </FormControl>
-                
-                <FormControl fullWidth variant="outlined" margin="normal">
-                  {<InputLabel margin="normal">Tutor/a</InputLabel>
-                  }
-                  <Select
-                    margin="normal"
-                    value={item.tutor_period_id || ""}
-                    label="Tutor"
-                    onChange={(e) =>
-                      setItem({ ...item, tutor_period_id: e.target.value })
-                    }
-                    required
+
+
+
+                  {/* Las tres preferencias, no editables */}
+                  <TextField
+                    variant="outlined"
                     fullWidth
-                  >
-                    <MenuItem key="" value="" disabled>
-                      Seleccionar tutor
-                    </MenuItem>
-                    {tutors.map((tutor) => {
-                      const tp = tutor.tutor_periods.find((tp) => tp.period_id === periodId);
-                      if (!tp) return null; // ignorar si no hay uno del period pedido
+                    margin="normal"
+                    label="Preferencia 1"
+                    value={item?.preferred_topics?.[0]
+                      ? getTopicNameById(item.preferred_topics[0])
+                      : ""}
+                    disabled
+                  />
+                  <TextField
+                    variant="outlined"
+                    fullWidth
+                    margin="normal"
+                    label="Preferencia 2"
+                    value={item?.preferred_topics?.[1]
+                      ? getTopicNameById(item.preferred_topics[1])
+                      : ""}
+                    disabled
+                  />
+                  <TextField
+                    fullWidth
+                    margin="normal"
+                    label="Preferencia 3"
+                    variant="outlined"
+                    value={item?.preferred_topics?.[2]
+                      ? getTopicNameById(item.preferred_topics[2])
+                      : ""}
+                    disabled
+                  />
+                  </Grid>
 
-                      return (
-                          <MenuItem key={tp.id} value={tp.id}>
-                          {tutor.name} {tutor.last_name}
-                          </MenuItem>
-                      );
-                      })}
-
-                  </Select>
-                </FormControl>
-
-
-
-                {/* Las tres preferencias, no editables */}
-                <TextField
-                  variant="outlined"
-                  fullWidth
-                  margin="normal"
-                  label="Preferencia 1"
-                  value={item?.preferred_topics?.[0]
-                    ? getTopicNameById(item.preferred_topics[0])
-                    : ""}
-                  disabled
-                />
-                <TextField
-                  variant="outlined"
-                  fullWidth
-                  margin="normal"
-                  label="Preferencia 2"
-                  value={item?.preferred_topics?.[1]
-                    ? getTopicNameById(item.preferred_topics[1])
-                    : ""}
-                  disabled
-                />
-                <TextField
-                  fullWidth
-                  margin="normal"
-                  label="Preferencia 3"
-                  variant="outlined"
-                  value={item?.preferred_topics?.[2]
-                    ? getTopicNameById(item.preferred_topics[2])
-                    : ""}
-                  disabled
-                />
+                </Grid> 
               </DialogContent>
 
               <DialogActions>

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -47,37 +47,19 @@ export const TeamModal = ({
 
       }, [openEditModal, item]);      
 
-      // AUX: ESTAS FUNCIONES DEBERÍAN SER IMPORTABLES []
+      // To-Do: Estas funciones deberían ser importables
       // Función para obtener el nombre del topic por su id
       const getTopicNameById = (id) => {
         if (id === "") return // AUX: agrego esta línea, para usar la función desde el modal de confirm, puedo mandarle "" si no tenía tema asignado.
         const topic = topics.csvTopics?.find((t) => t.id === id);        
         return topic ? topic.name : ""; // Si no encuentra el topic, mostrar 'Desconocido'
       };
-      // Función para obtener el nombre del tutor por su tutor period id
-        const getTutorNameById = (id, periodId) => {
-            const tutor = tutors.find(
-            (t) =>
-                t.tutor_periods &&
-                t.tutor_periods.some((tp) => tp.period_id === periodId && tp.id === id)
-            );
-            return tutor ? tutor.name + " " + tutor.last_name : "Sin asignar"; // Si no encuentra el tutor, mostrar 'Sin asignar'
-        };
         
-    // AUX
-    const getTopicById = (id) => {
+      // Nueva función, para obtener el objeto topic
+      const getTopicById = (id) => {
         const topic = topics.csvTopics?.find((t) => t.id === id);
         return topic ? topic : ""; // Si no encuentra el topic, mostrar 'Desconocido'
       };
-    // Función para obtener el nombre del tutor por su id
-    const getTutorEmailByTutorPeriodId = (id, periodId) => {
-        const tutor = tutors.find(
-        (t) =>
-            t.tutor_periods &&
-            t.tutor_periods.some((tp) => tp.period_id === periodId && tp.id === id)
-        );
-        return tutor ? tutor.email : "Sin asignar"; // Si no encuentra el tutor, mostrar 'Sin asignar'
-    };
 
       /////// Modals ///////
       // Este modal va a ser el de editar directamente (hay add en StudentForm).

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -360,7 +360,7 @@ export const TeamModal = ({
                 {conflictMsg?.empty_delete_team && (<div>
                   <h4>Equipo vacío</h4>
                   <ul>
-                      <li>Se eliminarán todos los integrantes de este equipo</li>                    
+                      <li>Se desasignarán todos los integrantes de este equipo</li>                    
                   </ul>
                   Confirmar desasignará todos los integrantes de este equipo y eliminará el equipo.
                 </div>

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -66,7 +66,7 @@ export const TeamModal = ({
       // Conservo la estructura solo x comodidad / analogía con otros archivos de modals.
       const innerEditTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
         return (
-          <Dialog open={bool} maxWidth={false} fullWidth PaperProps={{
+          <Dialog open={bool} onClose={handleCloseModal} maxWidth={false} fullWidth PaperProps={{
             style: {
               height: "90vh",
               maxHeight: "90vh", // Limita la altura máxima para que no desborde
@@ -149,11 +149,6 @@ export const TeamModal = ({
                           </Grid>                          
                       )} 
                     </Grid>
-
-                    {/*
-                    // Aux:
-                    // Pero no confiar, VER qué pasa con el orden de students, viene desde el back. [].
-                    */}
                   </Grid>
 
                   {/* Columna derecha */}

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -146,6 +146,10 @@ export const TeamModal = ({
                       Integrantes
                     </Typography>*/
                     }
+
+                    {////////////////////////////////////////////////
+
+                    }
                     <InputLabel>Integrantes</InputLabel>
                     {/* Integrante 1 */}
                     <Grid container spacing={2} sx={{ marginBottom: 2 }}>
@@ -286,63 +290,11 @@ export const TeamModal = ({
                       </Grid>
 
                     </Grid>
-
-                    {/*//////////////////////////////////
                     */
-                    }
-                    {/* Integrante 2 - generalizar */}
-                    {/*<NumericFormat
-                      //fullWidth
-                      allowNegative={false}
-                      customInput={TextField}
-                      variant="outlined"
-                      autoFocus
-                      margin="normal"
-                      label="Padrón integrante 2"
-                      value={item?.students?.[1].id || ""}
-                      onChange={(e) =>
-                        {const newStudents = [...item.students];
-                        newStudents[1] = { ...newStudents[1], id: parseInt(e.target.value) };
-                        setItem({ ...item, students: newStudents });
-                        }
-                      }
-                    />
-                    <NumericFormat
-                      fullWidth
-                      allowNegative={false}
-                      customInput={TextField}
-                      variant="outlined"
-                      autoFocus
-                      margin="normal"
-                      label="Padrón integrante 3"
-                      value={item?.students?.[2].id || ""}
-                      onChange={(e) =>
-                        {const newStudents = [...item.students];
-                            newStudents[2] = { ...newStudents[2], id: parseInt(e.target.value) };
-                            setItem({ ...item, students: newStudents });
-                        }
-                      }
-                    />
-                    <NumericFormat
-                      fullWidth
-                      allowNegative={false}
-                      customInput={TextField}
-                      variant="outlined"
-                      autoFocus
-                      margin="normal"
-                      label="Padrón integrante 4"
-                      value={item?.students?.[3].id || ""}
-                      onChange={(e) =>
-                        {const newStudents = [...item.students];
-                            newStudents[3] = { ...newStudents[3], id: parseInt(e.target.value) };
-                            setItem({ ...item, students: newStudents });
-                        }
-                      }
-                      // Aux:
-                      // Pero no confiar, VER qué pasa con el orden de students, viene desde el back. [].
-                    />
-                      */}
-
+                    {/*
+                    // Aux:
+                    // Pero no confiar, VER qué pasa con el orden de students, viene desde el back. [].
+                    */}
                   </Grid>
 
                   {/* Columna derecha */}

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -305,7 +305,7 @@ export const TeamModal = ({
       }
       
       const confirmEditOnConflictTeamModal = () => {
-        // Usa el editedItem, por lo que en el medio, no se debe haber flusheado editedItem (ej hay que no cerrar el modal anterior)
+        // Usa el editedItem, por lo que en el medio, no se debe haber flusheado editedItem (ej hay que no cerrar (desde afuera) el modal anterior si hay conflicto)
         // Además, luego de Confirmar se necesita usar desde afuera al editedItem por lo que no hay que flushearlo desde acá sino afuera
         console.log("--- VIENDO DESDE ADENTRO OTRA VEZ, EL BOOL: ",openConfirmModal);
         //return innerConfirmEditOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModal, message, handleConfirm, editedItem, setEditedItem, "", "Confirmar") // da error en inglés de que studentsInput es undefined, xq editedItem se flusheó

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -120,30 +120,30 @@ export const TeamModal = ({
                     {/* Integrantes */}                    
                     <InputLabel sx={{ mb: 2 }}>Integrantes</InputLabel> {/* mb = marginBottom */}
                     {item?.students?.map((student, index) => (
-                      <>                     
-                        <Grid container spacing={2} sx={{ marginBottom: 2 }}>
-                          <Grid item xs={12}>                          
-                            <Autocomplete
-                              disablePortal
-                              options={students || []}
-                              getOptionLabel={(option) => option.id? `${option.id} - ${option.name} ${option.last_name}` : ""} // cómo mostrar el texto
-                              sx={{ width: '100%' }}
-                              renderInput={(students) => <TextField {...students}
-                                                            label=""/>}
-                              onChange={(event, newValue) => {
-                                const newStudents = item.students ? [...item.students] : [];
-                                if (newValue) {
-                                  newStudents[index] = newValue;
-                                } else {
-                                  newStudents[index] = { id: "", name: "", last_name: "" } // dejarlo vacío al quitar la selección
-                                }
-                                setItem({ ...item, students: newStudents });
-                              }}
-                              value={item?.students ? item.students[index] : null}
-                            />
-                          </Grid>
+                                        
+                      <Grid container spacing={2} sx={{ marginBottom: 2 }}>
+                        <Grid item xs={12}>                          
+                          <Autocomplete
+                            disablePortal
+                            options={students || []}
+                            getOptionLabel={(option) => option.id? `${option.id} - ${option.name} ${option.last_name}` : ""} // cómo mostrar el texto
+                            sx={{ width: '100%' }}                            
+                            renderInput={(students) => <TextField {...students}
+                                                          label=""/>}
+                            onChange={(event, newValue) => {
+                              const newStudents = item.students ? [...item.students] : [];
+                              if (newValue) {
+                                newStudents[index] = newValue;
+                              } else {
+                                newStudents[index] = { id: "", name: "", last_name: "" } // dejarlo vacío al quitar la selección
+                              }
+                              setItem({ ...item, students: newStudents });
+                            }}
+                            value={item?.students ? item.students[index] : null}
+                          />
                         </Grid>
-                      </>
+                      </Grid>
+                      
                     ))}
                     
                     <Grid container spacing={2} sx={{ marginBottom: 2 }}>
@@ -382,9 +382,9 @@ export const TeamModal = ({
 
   return (
     <>
-      {/*addTeamModal()*/};
-      {editTeamModal()};
-      {confirmEditOnConflictTeamModal()};
+      {/*addTeamModal()*/}
+      {editTeamModal()}
+      {confirmEditOnConflictTeamModal()}
     </>
   )
 }

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -31,8 +31,8 @@ export const TeamModal = ({
   setParentItem,
   conflictMsg, // para pasarle el msg de la response del back al modal de conflicto, y su set
   setConflictMsg,
-  topics, // para buscar su email etc a partir de otros datos
-  tutors,
+  topics, // desglosado en csvTopics y customTopics para que los custom se muestren pero No sean seleccionables
+  tutors, // para buscar su email etc a partir de otros datos
   students,
   periodId // para identificar el dato correcto en esas búsquedas
   
@@ -51,7 +51,7 @@ export const TeamModal = ({
       // Función para obtener el nombre del topic por su id
       const getTopicNameById = (id) => {
         if (id === "") return // AUX: agrego esta línea, para usar la función desde el modal de confirm, puedo mandarle "" si no tenía tema asignado.
-        const topic = topics.find((t) => t.id === id);
+        const topic = topics.csvTopics?.find((t) => t.id === id);        
         return topic ? topic.name : ""; // Si no encuentra el topic, mostrar 'Desconocido'
       };
       // Función para obtener el nombre del tutor por su tutor period id
@@ -66,7 +66,7 @@ export const TeamModal = ({
         
     // AUX
     const getTopicById = (id) => {
-        const topic = topics.find((t) => t.id === id);
+        const topic = topics.csvTopics?.find((t) => t.id === id);
         return topic ? topic : ""; // Si no encuentra el topic, mostrar 'Desconocido'
       };
     // Función para obtener el nombre del tutor por su id
@@ -189,7 +189,7 @@ export const TeamModal = ({
                         label="Tema"
                         required
                       >
-                        {topics.map((topic) => (
+                        {topics.csvTopics.map((topic) => (
                           <MenuItem
                             key={topic.id}
                             value={topic.id}
@@ -197,6 +197,14 @@ export const TeamModal = ({
                             {topic.name}
                           </MenuItem>
                         ))}
+
+                        {/* Si el valor actual es un custom, agregarlo como opción (no seleccionable)
+                            para que se pueda mostrar como valor inicial al abrir el modal*/}
+                        {item.topic && !topics.csvTopics.some(t => t.id === item.topic.id) && (
+                          <MenuItem key={item.topic.id} value={item.topic.id} disabled>
+                            {item.topic.name}
+                          </MenuItem>
+                        )}
                       </Select>
                     </FormControl>
                   

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -29,7 +29,8 @@ export const TeamModal = ({
   item, // recibido del parent, y su set para flushearlo al salir
   setParentItem,
   topics,
-  tutors
+  tutors,
+  periodId
   
 }) => {
 
@@ -65,11 +66,21 @@ export const TeamModal = ({
             );
             return tutor ? tutor.name + " " + tutor.last_name : "Sin asignar"; // Si no encuentra el tutor, mostrar 'Sin asignar'
         };
+        
     // AUX
     const getTopicById = (id) => {
         const topic = topics.find((t) => t.id === id);
         return topic ? topic : ""; // Si no encuentra el topic, mostrar 'Desconocido'
       };
+    // Función para obtener el nombre del tutor por su id
+    const getTutorEmailByTutorPeriodId = (id, periodId) => {
+        const tutor = tutors.find(
+        (t) =>
+            t.tutor_periods &&
+            t.tutor_periods.some((tp) => tp.period_id === periodId && tp.id === id)
+        );
+        return tutor ? tutor.email : "Sin asignar"; // Si no encuentra el tutor, mostrar 'Sin asignar'
+    };  
 
 
       /////// Modals ///////
@@ -174,7 +185,7 @@ export const TeamModal = ({
                 <FormControl fullWidth variant="outlined" margin="normal">
                     <InputLabel>Tema</InputLabel>
                     <Select
-                      value={item.topic?.id || "Sin asignar!!! VERRRRRR _acá no es donde se muestra"}
+                      value={item.topic?.id || ""}
                       onChange={(e) =>
                         setItem({ ...item, topic: getTopicById(e.target.value) })
                       }
@@ -195,10 +206,10 @@ export const TeamModal = ({
                 <InputLabel margin="normal">Seleccionar tutor</InputLabel>
                 <Select
                   margin="normal"
-                  value={item.tutor_email || "VERRRRR cómo mostrar su NyA"}
+                  value={item.tutor_period_id || ""}
                   label="Tutor"
                   onChange={(e) =>
-                    setItem({ ...item, tutor_email: e.target.value })
+                    setItem({ ...item, tutor_period_id: e.target.value })
                   }
                   required
                   fullWidth
@@ -206,11 +217,17 @@ export const TeamModal = ({
                   <MenuItem key="" value="" disabled>
                     Seleccionar tutor
                   </MenuItem>
-                  {tutors.map((tutor) => (
-                    <MenuItem key={tutor.email} value={tutor.email}>
-                      {getTutorNameById(tutor.email)}
-                    </MenuItem>
-                  ))}
+                  {tutors.map((tutor) => {
+                    const tp = tutor.tutor_periods.find((tp) => tp.period_id === periodId);
+                    if (!tp) return null; // ignorar si no hay uno del period pedido
+
+                    return (
+                        <MenuItem key={tp.id} value={tp.id}>
+                        {tutor.email}
+                        </MenuItem>
+                    );
+                    })}
+
                 </Select>
 
 
@@ -268,6 +285,14 @@ export const TeamModal = ({
       const editTeamModal = () => {
         return innerActionTeamModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
       }
+
+    //   console.log("HOLAAAA");
+    //   console.log("tutor ids", tutors.map(t => t.tutor_periods?.id));
+    //   if (item) {
+
+    //       console.log("item.tutor_period_id", item.tutor_period_id);
+    //   }
+          
 
   return (
     <>

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -57,7 +57,7 @@ export const TeamModal = ({
         const topic = topics.find((t) => t.id === id);
         return topic ? topic.name : ""; // Si no encuentra el topic, mostrar 'Desconocido'
       };
-      // Función para obtener el nombre del tutor por su id
+      // Función para obtener el nombre del tutor por su tutor period id
         const getTutorNameById = (id, periodId) => {
             const tutor = tutors.find(
             (t) =>
@@ -80,7 +80,9 @@ export const TeamModal = ({
             t.tutor_periods.some((tp) => tp.period_id === periodId && tp.id === id)
         );
         return tutor ? tutor.email : "Sin asignar"; // Si no encuentra el tutor, mostrar 'Sin asignar'
-    };  
+    };
+
+
 
 
       /////// Modals ///////
@@ -151,7 +153,6 @@ export const TeamModal = ({
                   label="Padrón integrante 2"
                   value={item?.students?.[1].id || ""}
                   onChange={(e) =>
-                    //setItem({ ...item, item.students.[1].id: parseInt(e.target.value) })
                     {const newStudents = [...item.students];
                     newStudents[1] = { ...newStudents[1], id: parseInt(e.target.value) };
                     setItem({ ...item, students: newStudents });
@@ -215,32 +216,35 @@ export const TeamModal = ({
                     </Select>
                   </FormControl>
                 
-                <InputLabel margin="normal">Seleccionar tutor</InputLabel>
-                <Select
-                  margin="normal"
-                  value={item.tutor_period_id || ""}
-                  label="Tutor"
-                  onChange={(e) =>
-                    setItem({ ...item, tutor_period_id: e.target.value })
+                <FormControl fullWidth variant="outlined" margin="normal">
+                  {<InputLabel margin="normal">Tutor/a</InputLabel>
                   }
-                  required
-                  fullWidth
-                >
-                  <MenuItem key="" value="" disabled>
-                    Seleccionar tutor
-                  </MenuItem>
-                  {tutors.map((tutor) => {
-                    const tp = tutor.tutor_periods.find((tp) => tp.period_id === periodId);
-                    if (!tp) return null; // ignorar si no hay uno del period pedido
+                  <Select
+                    margin="normal"
+                    value={item.tutor_period_id || ""}
+                    label="Tutor"
+                    onChange={(e) =>
+                      setItem({ ...item, tutor_period_id: e.target.value })
+                    }
+                    required
+                    fullWidth
+                  >
+                    <MenuItem key="" value="" disabled>
+                      Seleccionar tutor
+                    </MenuItem>
+                    {tutors.map((tutor) => {
+                      const tp = tutor.tutor_periods.find((tp) => tp.period_id === periodId);
+                      if (!tp) return null; // ignorar si no hay uno del period pedido
 
-                    return (
-                        <MenuItem key={tp.id} value={tp.id}>
-                        {tutor.email}
-                        </MenuItem>
-                    );
-                    })}
+                      return (
+                          <MenuItem key={tp.id} value={tp.id}>
+                          {tutor.name} {tutor.last_name}
+                          </MenuItem>
+                      );
+                      })}
 
-                </Select>
+                  </Select>
+                </FormControl>
 
 
 
@@ -296,15 +300,7 @@ export const TeamModal = ({
     
       const editTeamModal = () => {
         return innerActionTeamModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
-      }
-
-    //   console.log("HOLAAAA");
-    //   console.log("tutor ids", tutors.map(t => t.tutor_periods?.id));
-    //   if (item) {
-
-    //       console.log("item.tutor_period_id", item.tutor_period_id);
-    //   }
-          
+      }          
 
   return (
     <>

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -13,7 +13,8 @@ import {
     //
     FormControl,
     Typography,
-    Fab
+    Fab,
+    Autocomplete
 } from "@mui/material";
 import { NumericFormat } from "react-number-format";
 import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
@@ -34,6 +35,7 @@ export const TeamModal = ({
   setParentItem,
   topics,
   tutors,
+  students,
   periodId
   
 }) => {
@@ -148,46 +150,39 @@ export const TeamModal = ({
                       Integrantes
                     </Typography>*/
                     }
-
-                    {////////////////////////////////////////////////
-
-                    }
-                    <InputLabel>Integrantes</InputLabel>
+                    
                     {/* Integrantes */}                    
+                    <InputLabel sx={{ mb: 2 }}>Integrantes</InputLabel> {/* mb = marginBottom */}
                     {item?.students?.map((student, index) => (
-                      <Grid container spacing={2} sx={{ marginBottom: 2 }}>
-                        <Grid item xs={3}>
-                          <NumericFormat
-                            //fullWidth
-                            allowNegative={false}
-                            customInput={TextField}
-                            variant="outlined"
-                            autoFocus={index===0}
-                            margin="normal"
-                            label="Padrón"
-                            value={item?.students?.[index].id || ""}
-                            //required
-                            onChange={(e) =>
-                              {const newStudents = [...item.students];
-                                  newStudents[index] = { ...newStudents[index], id: parseInt(e.target.value) };
-                                  setItem({ ...item, students: newStudents });
-                                  }
-                            }                            
-                          />
+                      <>                     
+                        <Grid container spacing={2} sx={{ marginBottom: 2 }}>
+                          <Grid item xs={12}>                          
+                            <Autocomplete
+                              disablePortal
+                              //options={students.id }
+                              //options={`${students?.id || ""} - ${students?.name || ""} ${students?.last_name || ""}`}
+                              //options={students}
+                              options={students || []}
+                              getOptionLabel={(option) => option.id? `${option.id} - ${option.name} ${option.last_name}` : ""} // cómo mostrar el texto
+                              sx={{ width: '100%' }}
+                              renderInput={(students) => <TextField {...students}
+                                                            label=""/>}
+                              onChange={(event, newValue) => {
+                                const newStudents = item.students ? [...item.students] : [];
+                                if (newValue) {
+                                  newStudents[index] = newValue;
+                                } else {
+                                  newStudents[index] = { id: "", name: "", last_name: "" } // dejarlo vacío al quitar la selección
+                                }
+                                setItem({ ...item, students: newStudents });
+                              }}
+                              value={item?.students ? item.students[index] : null}
+                            />
+                          </Grid>
                         </Grid>
-                        <Grid item xs={9}>
-                          <TextField
-                            variant="outlined"
-                            fullWidth
-                            margin="normal"
-                            label="Nombre y Apellido"
-                            value={`${item.students?.[index]?.name || ""} ${item.students?.[index]?.last_name || ""}`}
-                            disabled
-                          />
-                        </Grid>                        
-                      </Grid>
+                      </>
                     ))}
-
+                    
                     <Grid container spacing={2} sx={{ marginBottom: 2 }}>
                       {item?.students?.length < 4 && (
                           <Grid item xs={12}>                            
@@ -208,7 +203,7 @@ export const TeamModal = ({
                           </Grid>                          
                       )} 
                     </Grid>
-                    
+
                     {/*
                     // Aux:
                     // Pero no confiar, VER qué pasa con el orden de students, viene desde el back. [].

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -45,7 +45,10 @@ export const TeamModal = ({
 
         setEditedItem(item); 
 
-      }, [openEditModal, item]);      
+      }, [openEditModal, item]);
+
+      const [editLoading, setEditLoading] = useState(false);
+      const [confirmLoading, setConfirmLoading] = useState(false);
 
       // To-Do: Estas funciones deberían ser importables
       // Función para obtener el nombre del topic por su id
@@ -64,7 +67,7 @@ export const TeamModal = ({
       /////// Modals ///////
       // Este modal va a ser el de editar directamente (hay add en StudentForm).
       // Conservo la estructura solo x comodidad / analogía con otros archivos de modals.
-      const innerEditTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
+      const innerEditTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {        
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth={false} fullWidth PaperProps={{
             style: {
@@ -89,9 +92,16 @@ export const TeamModal = ({
               {TitleText} Equipo {item.group_number}
             </DialogTitle>
             <form
-              onSubmit={(e) => {
-                e.preventDefault(); // previene el reload del form
-                handleConfirmAction(item, setItem, handleCloseModal);
+              onSubmit={async (e) => {
+                e.preventDefault(); // previene el reload del form                
+                
+                if (editLoading) return;
+                setEditLoading(true);
+                try {
+                  await handleConfirmAction(item, setItem, handleCloseModal);
+                } finally {
+                  setEditLoading(false);
+                }
               }}
             >
               <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>        
@@ -257,8 +267,8 @@ export const TeamModal = ({
                 <Button onClick={handleCloseModal} variant="outlined" color="error">
                   Cancelar
                 </Button>
-                <Button type="submit" variant="contained" color="primary">
-                  {ConfirmButtonText}
+                <Button type="submit" variant="contained" color="primary" disabled={editLoading}>
+                  {editLoading ? "Guardando..." : ConfirmButtonText}
                 </Button>
               </DialogActions>
             </form>
@@ -293,7 +303,7 @@ export const TeamModal = ({
         return innerConfirmEditOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleConfirm, editedItem, setEditedItem, "", "Confirmar")
       }
       
-      const innerConfirmEditOnConflictModal = (bool, handleCloseModal, handleCloseEditModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {
+      const innerConfirmEditOnConflictModal = (bool, handleCloseModal, handleCloseEditModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {        
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth={false}>
             <DialogTitle
@@ -308,9 +318,16 @@ export const TeamModal = ({
               Conflicto al Intentar Editar Equipo {item.group_number}
             </DialogTitle>
             <form
-              onSubmit={(e) => {
-                e.preventDefault(); // previene el reload del form
-                handleConfirmAction(item, setItem, handleCloseModal);
+              onSubmit={ async (e) => {
+                e.preventDefault(); // previene el reload del form                
+
+                if (confirmLoading) return;
+                setConfirmLoading(true);
+                try {
+                  await handleConfirmAction(item, setItem, handleCloseModal);
+                } finally {
+                  setConfirmLoading(false);
+                }
               }}
             >
               <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
@@ -356,8 +373,8 @@ export const TeamModal = ({
                 <Button onClick={handleCloseModal} variant="outlined" color="error">
                   Cancelar
                 </Button>
-                <Button type="submit" onClick={handleCloseEditModal} variant="contained" color="primary">
-                  {ConfirmButtonText}
+                <Button type="submit" onClick={handleCloseEditModal} variant="contained" color="primary" disabled={confirmLoading}>
+                  {confirmLoading ? "Confirmando..." : ConfirmButtonText}
                 </Button>
               </DialogActions>
             </form>

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -23,11 +23,11 @@ import AddIcon from "@mui/icons-material/Add";
 
 /* Modals para Agregar y Editar un/a estudiante */
 export const TeamModal = ({
-  //openAddModal, // bools para ver si se debe abrir cada modal
+  openAddModal, // bools para ver si se debe abrir cada modal
   openEditModal,
-  //setOpenAddModal, // necesarias para cerrar los modals
+  setOpenAddModal, // necesarias para cerrar los modals
   setOpenEditModal,
-  //handleAddItem, // las acciones al clickear confirmar desde cada modal
+  handleAddItem, // las acciones al clickear confirmar desde cada modal
   handleEditItem,
   originalEditedItemId, // para pasárselo a la función que habla con la api al confirmar, y su set para el handle
   setOriginalEditedItemId,
@@ -324,12 +324,68 @@ export const TeamModal = ({
     
       const editTeamModal = () => {
         return innerActionTeamModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
-      }          
+      }
+      
+      const confirmEditOnConflictTeamModal = () => {
+        // Aux: Tengo que crear el useState nuevo (bool open) desde afuera xq desde afuera lo voy a cerrar, y manejar eso
+        // y pasarle el msg para mostrarlo acá adentro
+        // Tmb falta la función que repite la request pero con un true
+
+        // Aux, tiene que ser obviamente un parámetro real y no esta cosa horrible (:
+        const res = {"detail":["Estudiante 103944 - JOAQUIN EMANUEL HETREA ya se encuentra en equipo 135","Estudiante 99779 - JUAN IGNACIO KRISTAL ya se encuentra en equipo 148"]};
+        const message = res.detail;
+        return innerConfirmEditOnConflictModal(openAddModal, handleCloseAddModal, message, handleAddItem, editedItem, setEditedItem, "", "Confirmar")
+      }
+      ////////////
+      const innerConfirmEditOnConflictModal = (bool, handleCloseModal, message, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {
+        return (
+          <Dialog open={bool} onClose={handleCloseModal} maxWidth={false}>
+            <DialogTitle
+              sx={{
+                fontWeight: "bold",
+                textAlign: "center",
+                backgroundColor: "#f5f5f5",
+                color: "#333",
+                padding: "16px 24px",
+              }}
+            >
+              Conflicto al Intentar Editar Equipo {item.group_number}
+            </DialogTitle>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault(); // previene el reload del form
+                handleConfirmAction(item, setItem, handleCloseModal);
+              }}
+            >
+              <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
+                
+                {/* Mostrar el / los errores */}
+                
+                    <ul>
+                      {message?.map((conflict_error, index) => (
+                        <li key={index}>{conflict_error}</li>
+                      ))}
+                    </ul>
+                    Confirmar eliminará cada estudiante de su actual equipo y lo agregará a este equipo.
+                    ¿Confirmar la edición?
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={handleCloseModal} variant="outlined" color="error">
+                  Cancelar
+                </Button>
+                <Button type="submit" variant="contained" color="primary">
+                  {ConfirmButtonText}
+                </Button>
+              </DialogActions>
+            </form>
+          </Dialog>
+        )};
 
   return (
     <>
       {/*addTeamModal()*/};
       {editTeamModal()};
+      {confirmEditOnConflictTeamModal()};
     </>
   )
 }

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -114,7 +114,7 @@ export const TeamModal = ({
                   autoFocus
                   margin="normal"
                   label="Padrón integrante 2"
-                  value={item["students"][1] || ""}
+                  value={item && item["students"] && item["students"][1] || ""}
                   required
                   onChange={(e) =>
                     setItem({ ...item, student_id_2: parseInt(e.target.value) })
@@ -129,7 +129,7 @@ export const TeamModal = ({
                   autoFocus
                   margin="normal"
                   label="Padrón integrante 3"
-                  value={item["students"][2] || ""}
+                  value={item && item["students"] && item["students"][2] || ""}
                   required
                   onChange={(e) =>
                     setItem({ ...item, student_id_3: parseInt(e.target.value) })
@@ -144,7 +144,7 @@ export const TeamModal = ({
                   autoFocus
                   margin="normal"
                   label="Padrón integrante 4"
-                  value={item["students"][3] || ""}
+                  value={item && item["students"] && item["students"][3] || ""}
                   required
                   onChange={(e) =>
                     setItem({ ...item, student_id_4: parseInt(e.target.value) })

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -82,7 +82,7 @@ export const TeamModal = ({
       /////// Modals ///////
       // Este modal va a ser el de editar directamente, y no existirá Add acá.
       // Conservo la estructura solo x comodidad / analogía con otros archivos de modals.
-      const innerActionTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
+      const innerEditTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
         return (
           <Dialog open={bool} maxWidth={false} fullWidth PaperProps={{
             style: {
@@ -287,6 +287,12 @@ export const TeamModal = ({
         setConflictMsg([]);        
       };
 
+      const handleCloseEditModalWithoutFlushingEditedItem = () => {
+        //setEditedItem({})
+        setOpenEditModal(false);
+        setParentItem(false);
+      };
+
       const handleCloseEditModal = () => {
         setEditedItem({})
         setOpenEditModal(false);
@@ -294,18 +300,13 @@ export const TeamModal = ({
       };
       
       const editTeamModal = () => {
-        return innerActionTeamModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
+        // Usa el editedItem para guardar el resultado de las ediciones a enviar
+        return innerEditTeamModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
       }
-
-      const handleCloseEditModalWithoutFlushingEditedItem = () => {
-        //setEditedItem({})
-        setOpenEditModal(false);
-        setParentItem(false);
-      };
       
       const confirmEditOnConflictTeamModal = () => {
-        //return innerConfirmEditOnConflictModal(openConfirmModal, handleCloseBothModals, message, handleConfirm, editedItem, setEditedItem, "", "Confirmar")
-        //return innerConfirmEditOnConflictModal(openConfirmModal, handleCloseAddModal, message, handleConfirm, editedItem, setEditedItem, "", "Confirmar") // cierra el de abajo y no éste
+        // Usa el editedItem, por lo que en el medio, no se debe haber flusheado editedItem (ej hay que no cerrar el modal anterior)
+        // Además, luego de Confirmar se necesita usar desde afuera al editedItem por lo que no hay que flushearlo desde acá sino afuera
         console.log("--- VIENDO DESDE ADENTRO OTRA VEZ, EL BOOL: ",openConfirmModal);
         //return innerConfirmEditOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModal, message, handleConfirm, editedItem, setEditedItem, "", "Confirmar") // da error en inglés de que studentsInput es undefined, xq editedItem se flusheó
         return innerConfirmEditOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleConfirm, editedItem, setEditedItem, "", "Confirmar")

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -92,7 +92,17 @@ export const TeamModal = ({
       // Conservo la estructura solo x comodidad / analogía con otros archivos de modals. Ver dsp []
       const innerActionTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
         return (
-          <Dialog open={bool} onClose={handleCloseModal} maxWidth={false} fullWidth>
+          <Dialog open={bool} onClose={handleCloseModal} maxWidth={false} fullWidth PaperProps={{
+            style: {
+              height: "90vh",
+              maxHeight: "90vh", // Limita la altura máxima para que no desborde
+              
+              borderRadius: "8px",
+              width: '1000px', //
+              maxWidth: '90vw', // opcional, por si en pantallas chicas
+            },
+          }}
+          >
             <DialogTitle
               sx={{
                 fontWeight: "bold",
@@ -102,7 +112,7 @@ export const TeamModal = ({
                 padding: "16px 24px",
               }}
             >
-              {TitleText} Equipo
+              {TitleText} Equipo {item.group_number}
             </DialogTitle>
             <form
               onSubmit={(e) => {
@@ -111,7 +121,8 @@ export const TeamModal = ({
               }}
             >
               <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
-              <NumericFormat
+                {/*Equipo {item.group_number}*/}
+              {/*<NumericFormat
                   fullWidth
                   allowNegative={false}
                   customInput={TextField}
@@ -125,18 +136,20 @@ export const TeamModal = ({
                     setItem({ ...item, id: parseInt(e.target.value) })
                   }
                   disabled
-                />
+                />*/}
                 {/* Campos editables */}
                 <Grid container spacing={2}>
                 {/* Columna izquierda */}
                   <Grid item xs={6} md={6}>
-                    {/* Integrantes */}
-                    <Typography variant="h6" gutterBottom>
+                    {/* Integrantes */}                    
+                    {/*<Typography variant="h6" gutterBottom>
                       Integrantes
-                    </Typography>
+                    </Typography>*/
+                    }
+                    <InputLabel>Integrantes</InputLabel>
                     {/* Integrante 1 */}
                     <Grid container spacing={2} sx={{ marginBottom: 2 }}>
-                      <Grid item xs={2}>
+                      <Grid item xs={3}>
                         <NumericFormat
                           //fullWidth
                           allowNegative={false}
@@ -155,12 +168,12 @@ export const TeamModal = ({
                           }
                         />
                       </Grid>
-                      <Grid item xs={10}>
+                      <Grid item xs={9}>
                         <TextField
                           variant="outlined"
-                          //fullWidth
+                          fullWidth
                           margin="normal"
-                          label="Nombre"
+                          label="Nombre y Apellido"
                           value={`${item.students?.[0]?.name || ""} ${item.students?.[0]?.last_name || ""}`}
                           required
                           onChange={(e) => setItem({ ...item, name: e.target.value })} // [] NO, VER.
@@ -227,6 +240,7 @@ export const TeamModal = ({
                   <Grid item xs={6} md={6}>
 
                   {/* Tema y tutor */} {/* aux: los copypasteo de StudentForm */}
+                  <InputLabel>Tema y Tutor/a</InputLabel>
                   <FormControl fullWidth variant="outlined" margin="normal">
                       <InputLabel>Tema</InputLabel>
                       <Select
@@ -281,6 +295,7 @@ export const TeamModal = ({
 
 
                   {/* Las tres preferencias, no editables */}
+                  <InputLabel>Preferencias</InputLabel>
                   <TextField
                     variant="outlined"
                     fullWidth

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -15,7 +15,6 @@ import {
     FormControl,
     Autocomplete
 } from "@mui/material";
-import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
 import Grid from "@mui/material/Grid";
 import AddIcon from "@mui/icons-material/Add";
 
@@ -50,6 +49,7 @@ export const TeamModal = ({
       // AUX: ESTAS FUNCIONES DEBERÍAN SER IMPORTABLES []
       // Función para obtener el nombre del topic por su id
       const getTopicNameById = (id) => {
+        if (id === "") return // AUX: agrego esta línea, para usar la función desde el modal de confirm, puedo mandarle "" si no tenía tema asignado.
         const topic = topics.find((t) => t.id === id);
         return topic ? topic.name : ""; // Si no encuentra el topic, mostrar 'Desconocido'
       };
@@ -332,14 +332,41 @@ export const TeamModal = ({
               <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
                 
                 {/* Mostrar el / los errores */}
-                
+
+                {conflictMsg?.student_conflicts?.length > 0 && (
+                  <div>
+                    <h4>Estudiantes</h4>
                     <ul>
-                      {conflictMsg?.map((conflict_error, index) => (
+                      {conflictMsg?.student_conflicts?.map((conflict_error, index) => (
                         <li key={index}>{conflict_error}</li>
                       ))}
                     </ul>
-                    Confirmar eliminará cada estudiante de su actual equipo y lo agregará a este equipo.
-                    ¿Confirmar la edición?
+                    Confirmar eliminará cada estudiante de su actual equipo y lo agregará a este equipo.                    
+                  </div>
+                )}
+
+                {conflictMsg?.topic_conflicts?.length > 0 && (
+                  <div>
+                    <h4>Tema</h4>                    
+                    <ul>
+                      {conflictMsg?.topic_conflicts?.map((conflict_error, index) => (
+                        <li key={index}>{conflict_error} {getTopicNameById(item.topic?.id)}</li>
+                      ))}
+                    </ul>
+                    Confirmar eliminará el tema de su actual equipo y lo asignará a este equipo.
+                  </div>
+                )}
+
+                {conflictMsg?.empty_delete_team && (<div>
+                  <h4>Equipo vacío</h4>
+                  <ul>
+                      <li>Se eliminarán todos los integrantes de este equipo</li>                    
+                  </ul>
+                  Confirmar desasignará todos los integrantes de este equipo y eliminará el equipo.
+                </div>
+                )}
+                
+                <p><strong>¿Confirmar la edición?</strong></p>
               </DialogContent>
               <DialogActions>
                 <Button onClick={handleCloseModal} variant="outlined" color="error">

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import {
     Button,
     TextField,
@@ -12,16 +12,14 @@ import {
     InputLabel,
     //
     FormControl,
-    Typography,
-    Fab,
     Autocomplete
 } from "@mui/material";
-import { NumericFormat } from "react-number-format";
 import { useOpenCloseStateModalLogic } from "./useOpenCloseStateModalLogic";
 import Grid from "@mui/material/Grid";
 import AddIcon from "@mui/icons-material/Add";
 
 /* Modals para Agregar y Editar un/a estudiante */
+// To-Do revisar estas props, alguna(s) sobra(n).
 export const TeamModal = ({
   openAddModal, // bools para ver si se debe abrir cada modal
   openEditModal,
@@ -33,15 +31,16 @@ export const TeamModal = ({
   setOriginalEditedItemId,
   item, // recibido del parent, y su set para flushearlo al salir
   setParentItem,
+  conflictMsg, // para pasarle el msg de la response del back al modal de conflicto, y su set
+  setConflictMsg,
   topics,
   tutors,
   students,
   periodId
   
 }) => {
-
-      console.log("--- VIENDO DESDE ADENTRO, EL BOOL: ",openAddModal);
       // Creo los estados, gestiono handle open, y obtengo los handle close.
+      // Aux: no se usaría esto, solo traer el const del editedItem para acá y lo demás no es relevante.
       const {
         newItem,
         setNewItem,
@@ -89,12 +88,9 @@ export const TeamModal = ({
         return tutor ? tutor.email : "Sin asignar"; // Si no encuentra el tutor, mostrar 'Sin asignar'
     };
 
-
-
-
       /////// Modals ///////
-      // Aux: este modal va a ser el de editar directamente, y no existirá por ahora Add acá.
-      // Conservo la estructura solo x comodidad / analogía con otros archivos de modals. Ver dsp []
+      // Este modal va a ser el de editar directamente, y no existirá Add acá.
+      // Conservo la estructura solo x comodidad / analogía con otros archivos de modals.
       const innerActionTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {
         return (
           <Dialog open={bool} maxWidth={false} fullWidth PaperProps={{
@@ -125,32 +121,11 @@ export const TeamModal = ({
                 handleConfirmAction(item, setItem, handleCloseModal);
               }}
             >
-              <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>
-                {/*Equipo {item.group_number}*/}
-              {/*<NumericFormat
-                  fullWidth
-                  allowNegative={false}
-                  customInput={TextField}
-                  variant="outlined"
-                  autoFocus
-                  margin="normal"
-                  label="Equipo número"
-                  value={item["id"] || ""}
-                  required
-                  onChange={(e) =>
-                    setItem({ ...item, id: parseInt(e.target.value) })
-                  }
-                  disabled
-                />*/}
+              <DialogContent dividers sx={{ padding: "24px 24px 16px" }}>        
                 {/* Campos editables */}
                 <Grid container spacing={2}>
                 {/* Columna izquierda */}
                   <Grid item xs={6} md={6}>
-                    {/* Integrantes */}                    
-                    {/*<Typography variant="h6" gutterBottom>
-                      Integrantes
-                    </Typography>*/
-                    }
                     
                     {/* Integrantes */}                    
                     <InputLabel sx={{ mb: 2 }}>Integrantes</InputLabel> {/* mb = marginBottom */}
@@ -160,9 +135,6 @@ export const TeamModal = ({
                           <Grid item xs={12}>                          
                             <Autocomplete
                               disablePortal
-                              //options={students.id }
-                              //options={`${students?.id || ""} - ${students?.name || ""} ${students?.last_name || ""}`}
-                              //options={students}
                               options={students || []}
                               getOptionLabel={(option) => option.id? `${option.id} - ${option.name} ${option.last_name}` : ""} // cómo mostrar el texto
                               sx={{ width: '100%' }}
@@ -197,7 +169,6 @@ export const TeamModal = ({
                                 setItem({ ...item, students: newStudents });
                               }}                              
                             >
-
                               Agregar Integrante
                             </Button>
 
@@ -268,7 +239,6 @@ export const TeamModal = ({
                   </FormControl>
 
 
-
                   {/* Las tres preferencias, no editables */}
                   <InputLabel>Preferencias</InputLabel>
                   <TextField
@@ -318,32 +288,16 @@ export const TeamModal = ({
           </Dialog>
         )
       };
-
-      const addTeamModal = () => {
-        // To-Doreturn innerActionStudentModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Agregar")
-      }
     
       const editTeamModal = () => {
         return innerActionTeamModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
       }
 
-      const handleCloseBothModals = () => {
-        // "add" (confirm modal)
-        setNewItem({})
-        setOpenAddModal(false);
-        //setParentItem(false);
-
-        // edit
-        setEditedItem({})
-        setOpenEditModal(false);
-        setParentItem(false);
-      };
       const handleCloseConfirmModal = () => {
-        console.log("--- HOLAAA, DESDE TEAM MODAL, BOOL:", openAddModal);
         setNewItem({}); // a esto no lo uso en este caso, se puede borrar esta línea
         setOpenAddModal(false);
         //setParentItem(false); // este item
-        console.log("--- DESDE TEAM MODAL, CERRÉ SUPUESTAMENTE EL BOOL:", openAddModal);
+        setConflictMsg([]);        
       };
 
       const handleCloseEditModalWithoutFlushingEditedItem = () => {
@@ -353,21 +307,14 @@ export const TeamModal = ({
       };
       
       const confirmEditOnConflictTeamModal = () => {
-        // Aux: Tengo que crear el useState nuevo (bool open) desde afuera xq desde afuera lo voy a cerrar, y manejar eso
-        // y pasarle el msg para mostrarlo acá adentro
-        // Tmb falta la función que repite la request pero con un true
-
-        // Aux, tiene que ser obviamente un parámetro real y no esta cosa horrible (:
-        const res = {"detail":["Estudiante 103944 - JOAQUIN EMANUEL HETREA ya se encuentra en equipo 135","Estudiante 99779 - JUAN IGNACIO KRISTAL ya se encuentra en equipo 148"]};
-        const message = res.detail;
         //return innerConfirmEditOnConflictModal(openAddModal, handleCloseBothModals, message, handleAddItem, editedItem, setEditedItem, "", "Confirmar")
         //return innerConfirmEditOnConflictModal(openAddModal, handleCloseAddModal, message, handleAddItem, editedItem, setEditedItem, "", "Confirmar") // cierra el de abajo y no éste
         console.log("--- VIENDO DESDE ADENTRO OTRA VEZ, EL BOOL: ",openAddModal);
         //return innerConfirmEditOnConflictModal(openAddModal, handleCloseConfirmModal, handleCloseEditModal, message, handleAddItem, editedItem, setEditedItem, "", "Confirmar") // da error en inglés de que studentsInput es undefined, xq editedItem se flusheó
-        return innerConfirmEditOnConflictModal(openAddModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, message, handleAddItem, editedItem, setEditedItem, "", "Confirmar")
+        return innerConfirmEditOnConflictModal(openAddModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleAddItem, editedItem, setEditedItem, "", "Confirmar")
       }
-      ////////////
-      const innerConfirmEditOnConflictModal = (bool, handleCloseModal, handleCloseEditModal, message, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {
+      
+      const innerConfirmEditOnConflictModal = (bool, handleCloseModal, handleCloseEditModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth={false}>
             <DialogTitle
@@ -392,7 +339,7 @@ export const TeamModal = ({
                 {/* Mostrar el / los errores */}
                 
                     <ul>
-                      {message?.map((conflict_error, index) => (
+                      {conflictMsg?.map((conflict_error, index) => (
                         <li key={index}>{conflict_error}</li>
                       ))}
                     </ul>

--- a/src/components/UI/Tables/ParentTable.js
+++ b/src/components/UI/Tables/ParentTable.js
@@ -207,7 +207,7 @@ const ParentTable = ({
         await editItemInGenericTable(editTopic, editedItem, setEditedItem, setTopics);
       }
     } catch (err) {
-      console.error(`Error when editing new ${title}:`, err);
+      console.error(`Error when editing ${title}:`, err);
       setNotification({
         open: true,
         message: `Error al editar ${TableTypeSingularLabel[title]||''}.`,


### PR DESCRIPTION
# Nueva funcionalidad "Editar equipo" :)
Esta feature quedó muy grande, x eso tardó tanto (quizás había que partirla en partes más pequeñas).
Y es un 3x1: cierra issues (solo tenemos 2 issues, ja) tpf-v2/assignment-service#25 y tpf-v2/assignment-service#24.

## Con esto, en la tabla de Equipos
- **Se realiza request get** para no tener que salir a la pantalla anterior y volver a entrar para que se hiciera el get.
- **Se agrega** el handle para editar (**handleEditItem**), con su llamada a la api.
- **Post editar**, el back devuelve cómo quedó lo modificado en formato `{"edited": [lista de objetos Equipo que fueron editados], "deleted": [lista de ids de equipos que fueron eliminados (solo es uno en realidad)]}`. Ahora **el front recorre esa respuesta y actualiza su lista de equipos para reflejar los cambios inmediatamente** en el render del contenido de la tabla.
- Además de eso, ese handle para editar tiene un campo booleano que por defecto es false que le indica al front que la decisión ante conflictos es Sí continuar con la edición. **Se agrega** entonces otro handle que es para confirmar (**handleConfirmEditOnConflict**) y hace exactamente **lo mismo que el de editar pero** pasando este **bool de move en true**.

Desde el modal de editar, **es posible editar** a sus **integrantes**, eliminarlos clickeando la crucecita a su derecha, y "agregar integrante" clickeando el botón con ese nombre que aparece si el equipo tiene menos de 4 integrantes. Además se puede editar el **tutor/a, y el tema.**

## Más sobre Conflictos y Move
El front envía la request para editar, y **checkea el status code** de la response del back: si fue **ok** terminó ahí; si fue 409 **conflict**, abre el modal de confirmar (sin cerrar el modal de edición, que ahora queda por debajo) e informa de los conflictos.
Los posibles conflictos son
- **estudiante** que se intenta agregar **ya estaba en otro equipo** ¿desea moverlo a éste?
- al **tema** que se intenta asignar **ya lo tenía otro(s) equipo(s)** ¿desea moverlo a éste?
- se informa que, siendo que se está indicando eliminar a todos los integrantes, luego de desasignarlos se eliminará este quipo xq queda vacío ¿continuar?
Se puede cancelar, y volver entonces al modal de edición para seguir editando; o confirmar y se realizarán esos moves.
(El modal **puede informar más de un conflicto a la vez**, y de confirmar se confirma todo.)
 - si se mueve estudiante, el equipo anterior entonces quedará con un integrante menos de la cantidad que tenía.
 - **si se mueve tema, el equipo (o equipoS) anterior** entonces, **quedará SIN tema.**
    -  para simplificar revisar qué equipos quedaron sin tema durante este proceso de edición, se agregaron botones **"Mostrar equipos sin tema"**, y "Mostrar equipos sin tutor" (este no tiene que ver con los "move", nunca se desasigna tutor de equipo anterior, no se lo considera un conflicto. Solo se agregó el botón #yaQueEstábamos).

## Además, cuestiones visuales
- se agrega **ExpandableCell**, y en la tabla de equipos **se 'ocultan' por defecto las tres columnas de preferencias**, y se pueden mostrar/ocultar con un nuevo botón de "Mostrar(/ocultar) preferenciasm. **Xq antes las filas eran tan largas que no se veía el botón de editar sin scrollear. Con esto el botón de Editar está visible a simple vista**, y luego sí se pueden mostrar las preferencias si se lo desea.
- se pone el **padrón como primera columna de sus estudiantes**, por uniformidad con la otra tabla de Estudiantes.
- se agregan esos dos botones de **"Mostrar equipos sin tema" y "Mostrar equipos sin tutor"**. Ambos **pueden combinarse** para mostrar la intersección de sus resultados. Y su leyenda cambia a "Mostrar todos los equipos" una vez clickeados.
Se agrega archivo teamModal para el modal de editar y el de confirmar edición.

- minor renames, cambio algunas variables "group" por "team", siempre dentro de estos archivos de esta feature
## Sobre Temas (lo que ya hablamos x wsp)
  **El back** devuelve, en el get de topics, solamente los temas que provienen del csv de fontela, y **No devuelve los** que inventó la gente en el campo de texto libre que figura al seleccionar **"Ya tengo tema y tutor"** (llamémoslos "temas custom"). Las funciones del back que se encargan de eso se usan extensamente, por lo que no quise cambiar lo que devuelve y romper otras funcionalidades.
  El campo Autocomplete de la librería mui acá en react, se maneja con ids, y debo buscar el id en una lista de temas (los "topics" que traje con ese get), pero como no devuelve temas custom, si el equipo en cuestión tenía un tema custom se rompía y mostraba vacío. La solución actual es construir un diccionario "**allTopics**" que tiene los "**csvTopics**" (los del get) y los "**customTopics**" que se obtienen iterando los equipos y guardando sus temas si no están en la lista de csvTopics.
  **Se revisará** si conviene agregar un campo en la tabla Topics (y qué valores ponerle) cuando se inicie la feature de proponer idea.

---

Si llegaron hasta acá: #saludos, xd, realmente fue muy larga esta feature :).