### PR TITLE
Feat/agregar equipo

### DIFF
--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -35,6 +35,54 @@ export const sendGroupForm = async (period, payload, existingGroup, user) => {
   }
 };
 
+
+// inner
+export const createTeam = async (periodId, payload, config) => {
+  
+  //TO-DO dynamic period in QP // [query parameter? pero sí es un query parameter]
+  const teamPayload = {
+    students_ids: [
+      payload.user_id_sender,
+      payload.user_id_student_2,
+      payload.user_id_student_3,
+      payload.user_id_student_4,
+    ],
+    
+    // Por convención, cuando se desea guardar al equipo con un tema determinado (sea porque Ya tiene tema y tutor, o porque
+    // admin agrega al equipo manualmente), el tema a guardar se pone en topic_1
+    topic: payload.topic_1,
+    tutor_email: payload.tutor_email
+  }
+
+  teamPayload.students_ids = teamPayload.students_ids.filter(uid => uid);
+  const response = await axios.post(`${BASE_URL}/groups/?period=${periodId}`, teamPayload, config);
+  return response;
+}
+
+export const addTeam = async (newItem, user, periodId) => {
+  const config = {
+    headers: {
+      Authorization: `Bearer ${user.token}`,
+    },
+  };
+  const intStudentIds = newItem.students
+  .map(s => s.id)
+  .filter(id => Number.isInteger(id));
+  
+  // Construyo un payload para reutilizar la función createTeam
+  const payload = {
+    user_id_sender: intStudentIds[0] || null,
+    user_id_student_2: intStudentIds[1] || null,
+    user_id_student_3: intStudentIds[2] || null,
+    user_id_student_4: intStudentIds[3] || null,
+    
+    topic_1: newItem.topic.name, // ver si tengo que mandar el name o el topic... _ [VER] [el back espera str pero acá nec id o algo]
+    
+    tutor_email: newItem.tutor_email || null,
+  };
+  return await createTeam(periodId, payload, config);
+}
+
 export const editTeam = async (groupId, periodId, teamToEdit, user, confirm_move=false) => {
   const config = {
       headers: {

--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -114,7 +114,11 @@ export const editTeam = async (groupId, periodId, teamToEdit, user, confirm_move
     "topic_id": teamToEdit.topic.id,
     "confirm_move": confirm_move,
     "confirm_topic_move": confirm_topic_move,
-  };  
+  };
+  // Editar equipo permite crear el tema, es por eso que en ese caso no existirá el topic id y sí su nombre
+  if (!teamToEdit.topic_id) {
+    sendableTeamToEdit["topic"] = teamToEdit.topic.name;
+  }
 
   try {
       const url = `${BASE_URL}/groups/${groupId}/periods/${periodId}`;

--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -37,6 +37,8 @@ export const sendGroupForm = async (period, payload, existingGroup, user) => {
 
 
 // inner
+// NOTAR que devuelve "response" y no "response.data". Lo mantengo tal cual por compatibilidad
+// con el sendGroupForm.
 export const createTeam = async (periodId, payload, config, confirm_move=false) => {
   
   //TO-DO dynamic period in QP // [query parameter? pero sí es un query parameter]
@@ -82,7 +84,8 @@ export const addTeam = async (newItem, user, periodId, confirm_move=false) => {
     
     tutor_email: newItem.tutor_email || null,
   };
-  return await createTeam(periodId, payload, config, confirm_move);
+  const response = await createTeam(periodId, payload, config, confirm_move);
+  return response.data;
 }
 
 export const editTeam = async (groupId, periodId, teamToEdit, user, confirm_move=false) => {

--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -39,7 +39,7 @@ export const sendGroupForm = async (period, payload, existingGroup, user) => {
 // inner
 // NOTAR que devuelve "response" y no "response.data". Lo mantengo tal cual por compatibilidad
 // con el sendGroupForm.
-export const createTeam = async (periodId, payload, config, confirm_move=false) => {
+export const createTeam = async (periodId, payload, config, confirm_move=false, confirm_topic_move=false) => {
   
   //TO-DO dynamic period in QP // [query parameter? pero sí es un query parameter]
   const teamPayload = {
@@ -55,7 +55,11 @@ export const createTeam = async (periodId, payload, config, confirm_move=false) 
     topic: payload.topic_1,
     tutor_email: payload.tutor_email,
 
+    // Campos de conflictos, si los había
     confirm_move: confirm_move,
+    confirm_topic_move: confirm_topic_move,
+
+
   }
 
   teamPayload.students_ids = teamPayload.students_ids.filter(uid => uid);
@@ -63,7 +67,7 @@ export const createTeam = async (periodId, payload, config, confirm_move=false) 
   return response;
 }
 
-export const addTeam = async (newItem, user, periodId, confirm_move=false) => {
+export const addTeam = async (newItem, user, periodId, confirm_move=false, confirm_topic_move=false) => {
   const config = {
     headers: {
       Authorization: `Bearer ${user.token}`,
@@ -84,7 +88,7 @@ export const addTeam = async (newItem, user, periodId, confirm_move=false) => {
     
     tutor_email: newItem.tutor_email || null,
   };
-  const response = await createTeam(periodId, payload, config, confirm_move);
+  const response = await createTeam(periodId, payload, config, confirm_move, confirm_topic_move);
   return response.data;
 }
 

--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -37,7 +37,7 @@ export const sendGroupForm = async (period, payload, existingGroup, user) => {
 
 
 // inner
-export const createTeam = async (periodId, payload, config) => {
+export const createTeam = async (periodId, payload, config, confirm_move=false) => {
   
   //TO-DO dynamic period in QP // [query parameter? pero sí es un query parameter]
   const teamPayload = {
@@ -51,7 +51,9 @@ export const createTeam = async (periodId, payload, config) => {
     // Por convención, cuando se desea guardar al equipo con un tema determinado (sea porque Ya tiene tema y tutor, o porque
     // admin agrega al equipo manualmente), el tema a guardar se pone en topic_1
     topic: payload.topic_1,
-    tutor_email: payload.tutor_email
+    tutor_email: payload.tutor_email,
+
+    confirm_move: confirm_move,
   }
 
   teamPayload.students_ids = teamPayload.students_ids.filter(uid => uid);
@@ -59,7 +61,7 @@ export const createTeam = async (periodId, payload, config) => {
   return response;
 }
 
-export const addTeam = async (newItem, user, periodId) => {
+export const addTeam = async (newItem, user, periodId, confirm_move=false) => {
   const config = {
     headers: {
       Authorization: `Bearer ${user.token}`,
@@ -80,7 +82,7 @@ export const addTeam = async (newItem, user, periodId) => {
     
     tutor_email: newItem.tutor_email || null,
   };
-  return await createTeam(periodId, payload, config);
+  return await createTeam(periodId, payload, config, confirm_move);
 }
 
 export const editTeam = async (groupId, periodId, teamToEdit, user, confirm_move=false) => {

--- a/src/api/sendGroupForm.js
+++ b/src/api/sendGroupForm.js
@@ -88,7 +88,7 @@ export const addTeam = async (newItem, user, periodId, confirm_move=false) => {
   return response.data;
 }
 
-export const editTeam = async (groupId, periodId, teamToEdit, user, confirm_move=false) => {
+export const editTeam = async (groupId, periodId, teamToEdit, user, confirm_move=false, confirm_topic_move=false) => {
   const config = {
       headers: {
         Authorization: `Bearer ${user.token}`,
@@ -109,6 +109,7 @@ export const editTeam = async (groupId, periodId, teamToEdit, user, confirm_move
     "tutor_email": teamToEdit.tutor_email,
     "topic_id": teamToEdit.topic.id,
     "confirm_move": confirm_move,
+    "confirm_topic_move": confirm_topic_move,
   };  
 
   try {

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -135,10 +135,9 @@ const GroupDataTable = () => {
       }
     }
   };
-  const addItemToGenericTable = async (apiAddFunction, newItem, setNewItem, setReducer, confirm_option=false, confirm_topic_move=false) => {
+  const addItemToGenericTable = async (apiAddFunction, newItem, setNewItem, setReducer, confirm_option=false, confirm_topic_move=false) => {    
     newItem.tutor_email = getTutorEmailByTutorPeriodId(newItem.tutor_period_id, period.id);
     const changes = await apiAddFunction(newItem, user, period.id, confirm_option); // add
-    console.log("--- changes post add:", changes);
     setNewItem({});
     setNotification({
       open: true,

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -12,6 +12,7 @@ import {
   TableRow,
   TextField,
   Button,
+  Fab,
   Box,
   Stack
 } from "@mui/material";
@@ -24,6 +25,7 @@ import { setGroups } from "../../redux/slices/groupsSlice";
 import { editTeam } from "../../api/sendGroupForm";
 import MySnackbar from "../UI/MySnackBar";
 import { getTableData } from "../../api/handleTableData";
+import AddIcon from "@mui/icons-material/Add";
 
 // Componente para la tabla de equipos
 const GroupDataTable = () => {
@@ -64,6 +66,8 @@ const GroupDataTable = () => {
 
   const [openEditModal, setOpenEditModal] = useState(false);
   const [itemToPassToModal, setItemToPassToModal] = useState(null);
+
+  const [openAddModal, setOpenAddModal] = useState(false);
 
   // useEffect
   const endpoint = `/groups/?period=${period.id}`;
@@ -358,6 +362,15 @@ const GroupDataTable = () => {
               sx={{ marginBottom: 2 }}>
               {showExtraColumns ? "Ocultar preferencias" : "Mostrar preferencias"}
             </Button>
+
+            <Fab
+              size="small"
+              color="primary"
+              aria-label="add"                  
+              onClick={() => setOpenAddModal(true)}
+            >
+              <AddIcon />
+            </Fab>
           </Box>
 
           <TableContainer component={Paper}>
@@ -502,7 +515,10 @@ const GroupDataTable = () => {
             </Table>
           </TableContainer>
 
-          <TeamModal 
+          <TeamModal
+            openAddModal={openAddModal}
+            setOpenAddModal={setOpenAddModal}
+
             openEditModal={openEditModal}
             setOpenEditModal={setOpenEditModal}            
             handleEditItem={handleEditItem}

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -62,7 +62,7 @@ const GroupDataTable = () => {
   const [showNoTutor, setShowNoTutor] = useState(false);
 
   const [openConfirmEditModal, setOpenConfirmEditModal] = useState(false);
-  const [conflictsMessage, setConflictsMessage] = useState([]);
+  const [conflictsMessage, setConflictsMessage] = useState({msg:[]});
 
   const [openEditModal, setOpenEditModal] = useState(false);
   const [itemToPassToModal, setItemToPassToModal] = useState(null);
@@ -123,7 +123,7 @@ const GroupDataTable = () => {
 
         // Acá hay que indicarle de alguna forma que se abrió para solucionar conflictos DE ADD
         // set conflict type, o poner type y msg en un diccionario y abrirlo adentro
-        setConflictsMessage(err.response?.data?.detail || []);
+        setConflictsMessage({operation: "add", msg: err.response?.data?.detail} || {operation: "add", msg:[]});
         setOpenConfirmEditModal(true);
       }
     }
@@ -174,8 +174,8 @@ const GroupDataTable = () => {
           message: `Advertencia: Conflicto al editar equipo.`,
           status: "warning",
         });
-
-        setConflictsMessage(err.response?.data?.detail || []);
+        
+        setConflictsMessage({operation: "edit", msg: err.response?.data?.detail} || {operation: "edit", msg:[]});
         setOpenConfirmEditModal(true);
       }
     }
@@ -595,7 +595,7 @@ const GroupDataTable = () => {
             setOpenConfirmModal={setOpenConfirmEditModal}
             handleConfirm={handleConfirmEditOnConflict}
 
-            conflictMsg={conflictsMessage}
+            conflicts={conflictsMessage}
             setConflictMsg={setConflictsMessage}
 
             topics={allTopics}

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -20,7 +20,7 @@ import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import ExpandableCell from "../ExpandableCell";
 
-import { TeamModal } from "../UI/Tables/Modals/teamModal";
+import { TeamModals } from "../UI/Tables/Modals/teamModals";
 import { setGroups } from "../../redux/slices/groupsSlice";
 import { editTeam, addTeam } from "../../api/sendGroupForm";
 import MySnackbar from "../UI/MySnackBar";
@@ -574,7 +574,7 @@ const GroupDataTable = () => {
             </Table>
           </TableContainer>
 
-          <TeamModal
+          <TeamModals
             openAddModal={openAddModal}
             setOpenAddModal={setOpenAddModal}
             handleAddItem={handleAddItem}

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -74,15 +74,20 @@ const GroupDataTable = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const responseData = await getTableData(endpoint, user);
+        const responseData = await getTableData(endpoint, user); // TEAMS
 
         console.log("groups recibidos:", groups.map(g => ({id: g.id, "topic.id": g.topic?.id})));
-
+        // Minor 'fix' xq admin envía tema copypasteado en csv (con != tutor) queda id repetido y eso rompe búsqueda de Autocomplete
+        const uniqueTopics = Array.from(
+          new Map((topics ?? []).map(t => [t.id, t])).values()
+        );
         // Workaround a que el back no los devuelva: temas de "Ya tengo tema y tutor":
         const customTopics = groups?.filter(team => !topics.some(t => t.id === team.topic?.id))
         .map(team => team.topic);
-        setAllTopics({csvTopics: topics, customTopics: customTopics});
-        
+        setAllTopics({csvTopics: uniqueTopics, customTopics: customTopics});
+
+        console.log("--- uniqueTopics:", uniqueTopics);
+              
         setData(responseData);
         setLoading(false);
 

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -77,6 +77,7 @@ const GroupDataTable = () => {
         const responseData = await getTableData(endpoint, user); // TEAMS
 
         console.log("groups recibidos:", groups.map(g => ({id: g.id, "topic.id": g.topic?.id})));
+        
         // Minor 'fix' xq admin envía tema copypasteado en csv (con != tutor) queda id repetido y eso rompe búsqueda de Autocomplete
         const uniqueTopics = Array.from(
           new Map((topics ?? []).map(t => [t.id, t])).values()

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -98,8 +98,8 @@ const GroupDataTable = () => {
 
   // Agregar equipo. El first modal es en este caso el modal de add.
   // Es llamada desde TeamModals: primera vez queda bool en false; luego, si hay conflictos, con bool en true.
-  const handleAddItem = async (newItem, setNewItem, handleCloseFirstModal=undefined, confirm_option=false) => {
-    try {      
+  const handleAddItem = async (newItem, setNewItem, handleCloseFirstModal=undefined, confirm_option=false, confirm_topic_move=false) => {
+    try { // AUX: AGREGAR EL CAMPO CONFIRM_TOPIC_MOVE, QUE SOLO LO PUSE PARA NO ROMPER PERO AHORA NO HACE NADA.
       await addItemToGenericTable(addTeam, newItem, setNewItem, {}, confirm_option);
       if (handleCloseFirstModal) {
         handleCloseFirstModal(); // Esto cierra el primer modal solo si no hubo conflicto
@@ -147,10 +147,10 @@ const GroupDataTable = () => {
 
   // Editar equipo. El first modal es en este caso el modal de editar.
   // Es llamada desde TeamModals: primera vez queda bool en false; luego, si hay conflictos, con bool en true.
-  const handleEditItem = async (editedItem, setEditedItem, handleCloseFirstModal=undefined, confirm_option=false) => {
+  const handleEditItem = async (editedItem, setEditedItem, handleCloseFirstModal=undefined, confirm_option=false, confirm_topic_move=false) => {
     try {
       editedItem.tutor_email = getTutorEmailByTutorPeriodId(editedItem.tutor_period_id, period.id);
-      await editItemInGenericTable(editTeam, editedItem, setEditedItem, setGroups, confirm_option);
+      await editItemInGenericTable(editTeam, editedItem, setEditedItem, setGroups, confirm_option, confirm_topic_move);
       
       // Close modal de edición en caso de éxito sin conflictos
       if (handleCloseFirstModal) {
@@ -181,8 +181,8 @@ const GroupDataTable = () => {
       }
     }
   };
-  const editItemInGenericTable = async (apiEditFunction, editedItem, setEditedItem, setReducer, confirm_option=false) => {    
-    const changes = await apiEditFunction(editedItem.id, period.id, editedItem, user, confirm_option);
+  const editItemInGenericTable = async (apiEditFunction, editedItem, setEditedItem, setReducer, confirm_option=false, confirm_topic_move=false) => {    
+    const changes = await apiEditFunction(editedItem.id, period.id, editedItem, user, confirm_option, confirm_topic_move);
     setNotification({
       open: true,
       message: `Se editó equipo exitosamente`,

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -99,8 +99,8 @@ const GroupDataTable = () => {
   // Agregar equipo. El first modal es en este caso el modal de add.
   // Es llamada desde TeamModals: primera vez queda bool en false; luego, si hay conflictos, con bool en true.
   const handleAddItem = async (newItem, setNewItem, handleCloseFirstModal=undefined, confirm_option=false, confirm_topic_move=false) => {
-    try { // AUX: AGREGAR EL CAMPO CONFIRM_TOPIC_MOVE, QUE SOLO LO PUSE PARA NO ROMPER PERO AHORA NO HACE NADA.
-      await addItemToGenericTable(addTeam, newItem, setNewItem, {}, confirm_option);
+    try {
+      await addItemToGenericTable(addTeam, newItem, setNewItem, {}, confirm_option, confirm_topic_move);
       if (handleCloseFirstModal) {
         handleCloseFirstModal(); // Esto cierra el primer modal solo si no hubo conflicto
       }      
@@ -129,7 +129,7 @@ const GroupDataTable = () => {
       }
     }
   };
-  const addItemToGenericTable = async (apiAddFunction, newItem, setNewItem, setReducer, confirm_option=false) => {
+  const addItemToGenericTable = async (apiAddFunction, newItem, setNewItem, setReducer, confirm_option=false, confirm_topic_move=false) => {
     newItem.tutor_email = getTutorEmailByTutorPeriodId(newItem.tutor_period_id, period.id);
     const changes = await apiAddFunction(newItem, user, period.id, confirm_option); // add
     console.log("--- changes post add:", changes);

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -98,9 +98,9 @@ const GroupDataTable = () => {
   //}, [endpoint, user, groups, topics]);
 
   // Agregar equipo
-  const handleAddItem = async (newItem, setNewItem, handleCloseAddModal) => {
+  const handleAddItem = async (newItem, setNewItem, handleCloseAddModal, confirm_option=false) => {
     try {      
-      await addItemToGenericTable(addTeam, newItem, setNewItem, {});
+      await addItemToGenericTable(addTeam, newItem, setNewItem, {}, confirm_option);
       handleCloseAddModal(true);
       setNewItem({students:[]}); // necesario para el segundo modal, el de confirm.// <-- copypasteo esto acá, revisar en el modal
     } catch (err) {
@@ -121,16 +121,16 @@ const GroupDataTable = () => {
           status: "warning",
         });
 
+        // Acá hay que indicarle de alguna forma que se abrió para solucionar conflictos DE ADD
+        // set conflict type, o poner type y msg en un diccionario y abrirlo adentro
         setConflictsMessage(err.response?.data?.detail || []);
         setOpenConfirmEditModal(true);
       }
-    } finally {
-      
     }
   };
-  const addItemToGenericTable = async (apiAddFunction, newItem, setNewItem, setReducer) => {
+  const addItemToGenericTable = async (apiAddFunction, newItem, setNewItem, setReducer, confirm_option=false) => {
     newItem.tutor_email = getTutorEmailByTutorPeriodId(newItem.tutor_period_id, period.id);
-    const item = await apiAddFunction(newItem, user, period.id); // add
+    const item = await apiAddFunction(newItem, user, period.id, confirm_option); // add
     setNewItem({});
     setNotification({
       open: true,
@@ -219,6 +219,7 @@ const GroupDataTable = () => {
   
   // Confirmar edición con bool true
   const handleConfirmEditOnConflict = async (editedItem, setEditedItem, handleCloseEditModal, confirm_option=true) => {
+    // Esto capaz se puede hacer desde adentro
     await handleEditItem(editedItem, setEditedItem, handleCloseEditModal, true);
   };
   

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -117,7 +117,7 @@ const GroupDataTable = () => {
       if (err.response?.status===409) {
         setNotification({
           open: true,
-          message: `Advertencia: Conflicto al editar equipo.`,
+          message: `Advertencia: Conflicto al agregar equipo.`,
           status: "warning",
         });
 

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -22,7 +22,7 @@ import ExpandableCell from "../ExpandableCell";
 
 import { TeamModal } from "../UI/Tables/Modals/teamModal";
 import { setGroups } from "../../redux/slices/groupsSlice";
-import { editTeam } from "../../api/sendGroupForm";
+import { editTeam, addTeam } from "../../api/sendGroupForm";
 import MySnackbar from "../UI/MySnackBar";
 import { getTableData } from "../../api/handleTableData";
 import AddIcon from "@mui/icons-material/Add";
@@ -94,6 +94,37 @@ const GroupDataTable = () => {
     fetchData();
   }, [endpoint, user]);
   //}, [endpoint, user, groups, topics]);
+
+  // Agregar equipo
+  const handleAddItem = async (newItem, setNewItem, handleCloseAddModal) => {
+    try {      
+      await addItemToGenericTable(addTeam, newItem, setNewItem, {});
+    } catch (err) {
+      console.error(`Error when adding new team:`, err);
+      setNotification({
+        open: true,
+        //message: `Error al agregar ${TableTypeSingularLabel[title]||''}.`,        
+        message: `Error al agregar equipo.`,
+        status: "error",
+      });
+    } finally {
+      handleCloseAddModal(true);
+    }
+  };
+  const addItemToGenericTable = async (apiAddFunction, newItem, setNewItem, setReducer) => {
+    newItem.tutor_email = getTutorEmailByTutorPeriodId(newItem.tutor_period_id, period.id);
+    const item = await apiAddFunction(newItem, user, period.id); // add
+    setNewItem({});
+    setNotification({
+      open: true,
+      //message: `Se agregó ${TableTypeSingularLabel[title]||''} exitosamente`, // 'estudiante', etc
+      message: `Se agregó equipo exitosamente`, // 'estudiante', etc
+      status: "success",
+    });
+    setData((prevData) => [...prevData, item]);
+    //dispatch(setReducer((prevData) => [...prevData, item])); // set
+
+  };
 
   // Editar equipo
   const handleEditItem = async (editedItem, setEditedItem, handleCloseEditModal, confirm_option=false) => {
@@ -518,6 +549,7 @@ const GroupDataTable = () => {
           <TeamModal
             openAddModal={openAddModal}
             setOpenAddModal={setOpenAddModal}
+            handleAddItem={handleAddItem}
 
             openEditModal={openEditModal}
             setOpenEditModal={setOpenEditModal}            

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -77,7 +77,7 @@ export const TeamModal = ({
       /////// Modals ///////
       // Este modal va a ser el de editar directamente (hay add en StudentForm).
       // Conservo la estructura solo x comodidad / analogía con otros archivos de modals.
-      const innerEditTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {        
+      const innerEditTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {        
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth={false} fullWidth PaperProps={{
             style: {
@@ -312,7 +312,7 @@ export const TeamModal = ({
       
       const editTeamModal = () => {
         // Usa el editedItem para guardar el resultado de las ediciones a enviar
-        return innerEditTeamModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
+        return innerEditTeamModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar")
       }
       
       const confirmOnConflictTeamModal = () => {
@@ -326,8 +326,6 @@ export const TeamModal = ({
         } else if (conflicts?.operation == "edit") {
           return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleEditItem, editedItem, setEditedItem, "Editar", "Confirmar");
         }
-
-        //return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleConfirm, editedItem, setEditedItem, "Editar", "Confirmar");
       }
       
       const innerConfirmOnConflictModal = (bool, handleCloseModal, handleCloseFirstModal, handleActionToConfirm, item, setItem, TitleText, ConfirmButtonText) => {        
@@ -416,7 +414,7 @@ export const TeamModal = ({
       //// Add ////
       // Es todo lo mismo, salvo el título (no lleva item.id), y que no voy a mostrar acá las 3 preferencias
       // El loading tiene que ser un atributo
-      const innerAddTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText, disableEditId=false) => {        
+      const innerAddTeamModal = (bool, handleCloseModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {        
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth={false} fullWidth PaperProps={{
             style: {
@@ -593,8 +591,8 @@ export const TeamModal = ({
       };
 
       const addTeamModal = () => {
-        // Usa el editedItem para guardar el resultado de las ediciones a enviar <-- esto es copypaste, supongo que sería un newItem
-        return innerAddTeamModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Guardar", true)
+        // Usa el newItem para guardar lo que va a enviar
+        return innerAddTeamModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Guardar")
       }
 
   return (

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -305,13 +305,14 @@ export const TeamModal = ({
         return innerEditTeamModal(openEditModal, handleCloseEditModal, handleEditItem, editedItem, setEditedItem, "Editar", "Guardar", true)
       }
       
-      const confirmEditOnConflictTeamModal = () => {
+      const confirmOnConflictTeamModal = () => {
         // Usa el editedItem, por lo que en el medio, no se debe haber flusheado editedItem (ej hay que no cerrar (desde afuera) el modal anterior si hay conflicto)
         // Además, luego de Confirmar se necesita usar desde afuera al editedItem por lo que no hay que flushearlo desde acá sino afuera
-        return innerConfirmEditOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleConfirm, editedItem, setEditedItem, "", "Confirmar")
+        // AUX: acá un if type es edit hacer esto, else hacer lo mismo pero para add, y hay que agregar un blablawithputFlushing para add p q ande - #saludos me voy a cenar
+        return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleConfirm, editedItem, setEditedItem, "Editar", "Confirmar")
       }
       
-      const innerConfirmEditOnConflictModal = (bool, handleCloseModal, handleCloseEditModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {        
+      const innerConfirmOnConflictModal = (bool, handleCloseModal, handleCloseEditModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {        
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth={false}>
             <DialogTitle
@@ -323,7 +324,7 @@ export const TeamModal = ({
                 padding: "16px 24px",
               }}
             >
-              Conflicto al Intentar Editar Equipo {item.group_number}
+              Conflicto al Intentar {TitleText} Equipo {item.group_number}
             </DialogTitle>
             <form
               onSubmit={ async (e) => {
@@ -332,7 +333,7 @@ export const TeamModal = ({
                 if (confirmLoading) return;
                 setConfirmLoading(true);
                 try {
-                  await handleConfirmAction(item, setItem, handleCloseModal);
+                  await handleConfirmAction(item, setItem, handleCloseModal);                  
                 } finally {
                   setConfirmLoading(false);
                 }
@@ -375,7 +376,7 @@ export const TeamModal = ({
                 </div>
                 )}
                 
-                <p><strong>¿Confirmar la edición?</strong></p>
+                <p><strong>¿Confirmar?</strong></p>
               </DialogContent>
               <DialogActions>
                 <Button onClick={handleCloseModal} variant="outlined" color="error">
@@ -578,7 +579,7 @@ export const TeamModal = ({
     <>
       {addTeamModal()}
       {editTeamModal()}
-      {confirmEditOnConflictTeamModal()}
+      {confirmOnConflictTeamModal()}
     </>
   )
 }

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -19,7 +19,12 @@ import Grid from "@mui/material/Grid";
 import AddIcon from "@mui/icons-material/Add";
 const CLEARSTRING = "Eliminar integrante";
 
-/* Modals para Editar un equipo y Confirmar la edición en caso de conflicto */
+/* Modals para Agregar equipo, Editar equipo, y Confirmar la edición en caso de conflicto.
+ * Puede ocasionarse conflicto sea durante el agregado o durante la edición.
+ * Se llama "primer modal" al modal de add o edit, y "segundo modal" al de confirm,
+ * ya que el primer modal continúa en pantalla en caso de haber conflictos, y el de confirm
+ * se muestra por encima, hasta que se confirme (o se cancele) la operación.
+ */
 export const TeamModal = ({
   openAddModal, // bools para ver si se debe abrir cada modal
   openEditModal,
@@ -29,10 +34,9 @@ export const TeamModal = ({
   setOpenConfirmModal,
   handleAddItem, // las acciones al clickear confirmar desde cada modal
   handleEditItem,
-  handleConfirm,
   item, // recibido del parent, y su set para flushearlo al salir
   setParentItem,
-  conflicts, // para pasarle el msg de la response del back al modal de conflicto, y su set
+  conflicts, // para ver si fue x add o edit, y obtener el msg informando qué conflictos hubo; y su set
   setConflictMsg,
   topics, // desglosado en csvTopics y customTopics para que los custom se muestren pero No sean seleccionables
   tutors, // para buscar su email etc a partir de otros datos
@@ -46,6 +50,8 @@ export const TeamModal = ({
       // Esto hace de handle open edit
       useEffect(() => {
         if (!openEditModal) return;
+        // Importante: No continuar si el item ha sido flusheado
+        if (!item || Object.keys(item).length === 0) return;
 
         setEditedItem(item); 
 
@@ -345,8 +351,11 @@ export const TeamModal = ({
                 if (confirmLoading) return;
                 setConfirmLoading(true);
                 try {
+                  // cerramos el modal de confirm
+                  handleCloseModal();
+                  // undefined xq no necesitamos que ese handle cierre ningún modal, ya lo cerramos recién
                   // El true llega hasta la api call y confirma los conflictos! :)
-                  await handleActionToConfirm(item, setItem, handleCloseModal, true);            
+                  await handleActionToConfirm(item, setItem, undefined, true);
                 } finally {
                   setConfirmLoading(false);
                 }

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -348,12 +348,13 @@ export const TeamModal = ({
 
                 if (confirmLoading) return;
                 setConfirmLoading(true);
-                try {
+                try {                  
                   // cerramos el modal de confirm
-                  handleCloseModal();
+                  //handleCloseModal();
                   // undefined xq no necesitamos que ese handle cierre ningún modal, ya lo cerramos recién
+                  
                   // El true llega hasta la api call y confirma los conflictos! :)
-                  await handleActionToConfirm(item, setItem, undefined, true);
+                  await handleActionToConfirm(item, setItem, handleCloseModal, true);
                 } finally {
                   setConfirmLoading(false);
                 }

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -32,7 +32,7 @@ export const TeamModal = ({
   handleConfirm,
   item, // recibido del parent, y su set para flushearlo al salir
   setParentItem,
-  conflictMsg, // para pasarle el msg de la response del back al modal de conflicto, y su set
+  conflicts, // para pasarle el msg de la response del back al modal de conflicto, y su set
   setConflictMsg,
   topics, // desglosado en csvTopics y customTopics para que los custom se muestren pero No sean seleccionables
   tutors, // para buscar su email etc a partir de otros datos
@@ -283,10 +283,14 @@ export const TeamModal = ({
         setOpenAddModal(false);
         setNewItem({students: []});
       };
+
+      const handleCloseAddModalWithoutFlushingItem = () => {
+        setOpenAddModal(false);
+      };
         
       const handleCloseConfirmModal = () => {
         setOpenConfirmModal(false);
-        setConflictMsg([]);        
+        setConflictMsg({msg:[]});
       };
 
       const handleCloseEditModalWithoutFlushingEditedItem = () => {
@@ -309,7 +313,15 @@ export const TeamModal = ({
         // Usa el editedItem, por lo que en el medio, no se debe haber flusheado editedItem (ej hay que no cerrar (desde afuera) el modal anterior si hay conflicto)
         // Además, luego de Confirmar se necesita usar desde afuera al editedItem por lo que no hay que flushearlo desde acá sino afuera
         // AUX: acá un if type es edit hacer esto, else hacer lo mismo pero para add, y hay que agregar un blablawithputFlushing para add p q ande - #saludos me voy a cenar
-        return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleConfirm, editedItem, setEditedItem, "Editar", "Confirmar")
+        // if (conflicts?.operation == "add") {
+          
+        //   return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseAddModalWithoutFlushingItem, handleAddItem, newItem, setNewItem, "Agregar", "Confirmar");
+
+        // } else if (conflicts?.operation == "edit") {
+        //   return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleEditItem, editedItem, setEditedItem, "Editar", "Confirmar");
+        // }
+
+        return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleConfirm, editedItem, setEditedItem, "Editar", "Confirmar");
       }
       
       const innerConfirmOnConflictModal = (bool, handleCloseModal, handleCloseEditModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {        
@@ -333,7 +345,7 @@ export const TeamModal = ({
                 if (confirmLoading) return;
                 setConfirmLoading(true);
                 try {
-                  await handleConfirmAction(item, setItem, handleCloseModal);                  
+                  await handleConfirmAction(item, setItem, handleCloseModal);            
                 } finally {
                   setConfirmLoading(false);
                 }
@@ -343,11 +355,11 @@ export const TeamModal = ({
                 
                 {/* Mostrar el / los errores */}
 
-                {conflictMsg?.student_conflicts?.length > 0 && (
+                {conflicts?.msg?.student_conflicts?.length > 0 && (
                   <div>
                     <h4>Estudiantes</h4>
                     <ul>
-                      {conflictMsg?.student_conflicts?.map((conflict_error, index) => (
+                      {conflicts?.msg?.student_conflicts?.map((conflict_error, index) => (
                         <li key={index}>{conflict_error}</li>
                       ))}
                     </ul>
@@ -355,11 +367,11 @@ export const TeamModal = ({
                   </div>
                 )}
 
-                {conflictMsg?.topic_conflicts?.length > 0 && (
+                {conflicts?.msg?.topic_conflicts?.length > 0 && (
                   <div>
                     <h4>Tema</h4>                    
                     <ul>
-                      {conflictMsg?.topic_conflicts?.map((conflict_error, index) => (
+                      {conflicts?.msg?.topic_conflicts?.map((conflict_error, index) => (
                         <li key={index}>{conflict_error} {getTopicNameById(item.topic?.id)}</li>
                       ))}
                     </ul>
@@ -367,7 +379,7 @@ export const TeamModal = ({
                   </div>
                 )}
 
-                {conflictMsg?.empty_delete_team && (<div>
+                {conflicts?.msg?.empty_delete_team && (<div>
                   <h4>Equipo vacío</h4>
                   <ul>
                       <li>Se desasignarán todos los integrantes de este equipo</li>                    

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -313,18 +313,18 @@ export const TeamModal = ({
         // Usa el editedItem, por lo que en el medio, no se debe haber flusheado editedItem (ej hay que no cerrar (desde afuera) el modal anterior si hay conflicto)
         // Además, luego de Confirmar se necesita usar desde afuera al editedItem por lo que no hay que flushearlo desde acá sino afuera
         // AUX: acá un if type es edit hacer esto, else hacer lo mismo pero para add, y hay que agregar un blablawithputFlushing para add p q ande - #saludos me voy a cenar
-        // if (conflicts?.operation == "add") {
+        if (conflicts?.operation == "add") {
           
-        //   return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseAddModalWithoutFlushingItem, handleAddItem, newItem, setNewItem, "Agregar", "Confirmar");
+          return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseAddModalWithoutFlushingItem, handleAddItem, newItem, setNewItem, "Agregar", "Confirmar");
 
-        // } else if (conflicts?.operation == "edit") {
-        //   return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleEditItem, editedItem, setEditedItem, "Editar", "Confirmar");
-        // }
+        } else if (conflicts?.operation == "edit") {
+          return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleEditItem, editedItem, setEditedItem, "Editar", "Confirmar");
+        }
 
-        return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleConfirm, editedItem, setEditedItem, "Editar", "Confirmar");
+        //return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleConfirm, editedItem, setEditedItem, "Editar", "Confirmar");
       }
       
-      const innerConfirmOnConflictModal = (bool, handleCloseModal, handleCloseEditModal, handleConfirmAction, item, setItem, TitleText, ConfirmButtonText) => {        
+      const innerConfirmOnConflictModal = (bool, handleCloseModal, handleCloseFirstModal, handleActionToConfirm, item, setItem, TitleText, ConfirmButtonText) => {        
         return (
           <Dialog open={bool} onClose={handleCloseModal} maxWidth={false}>
             <DialogTitle
@@ -345,7 +345,8 @@ export const TeamModal = ({
                 if (confirmLoading) return;
                 setConfirmLoading(true);
                 try {
-                  await handleConfirmAction(item, setItem, handleCloseModal);            
+                  // El true llega hasta la api call y confirma los conflictos! :)
+                  await handleActionToConfirm(item, setItem, handleCloseModal, true);            
                 } finally {
                   setConfirmLoading(false);
                 }
@@ -394,7 +395,7 @@ export const TeamModal = ({
                 <Button onClick={handleCloseModal} variant="outlined" color="error">
                   Cancelar
                 </Button>
-                <Button type="submit" onClick={handleCloseEditModal} variant="contained" color="primary" disabled={confirmLoading}>
+                <Button type="submit" onClick={handleCloseFirstModal} variant="contained" color="primary" disabled={confirmLoading}>
                   {confirmLoading ? "Confirmando..." : ConfirmButtonText}
                 </Button>
               </DialogActions>

--- a/src/components/UI/Tables/Modals/teamModal.js
+++ b/src/components/UI/Tables/Modals/teamModal.js
@@ -21,13 +21,14 @@ const CLEARSTRING = "Eliminar integrante";
 
 /* Modals para Editar un equipo y Confirmar la edición en caso de conflicto */
 export const TeamModal = ({
-  openAddModal,
-  setOpenAddModal,
-  openEditModal, // bools para ver si se debe abrir cada modal
+  openAddModal, // bools para ver si se debe abrir cada modal
+  openEditModal,
   openConfirmModal,
-  setOpenEditModal, // necesarias para cerrar los modals
+  setOpenAddModal,  // necesarias para cerrar los modals
+  setOpenEditModal,
   setOpenConfirmModal,
-  handleEditItem, // las acciones al clickear confirmar desde cada modal
+  handleAddItem, // las acciones al clickear confirmar desde cada modal
+  handleEditItem,
   handleConfirm,
   item, // recibido del parent, y su set para flushearlo al salir
   setParentItem,
@@ -277,6 +278,10 @@ export const TeamModal = ({
             </form>
           </Dialog>
         )
+      };
+      const handleCloseAddModal = () => {
+        setOpenAddModal(false);
+        setNewItem({students: []});
       };
         
       const handleCloseConfirmModal = () => {
@@ -566,7 +571,7 @@ export const TeamModal = ({
 
       const addTeamModal = () => {
         // Usa el editedItem para guardar el resultado de las ediciones a enviar <-- esto es copypaste, supongo que sería un newItem
-        return innerAddTeamModal(openAddModal, {}, {}, newItem, setNewItem, "Agregar", "Guardar", true)
+        return innerAddTeamModal(openAddModal, handleCloseAddModal, handleAddItem, newItem, setNewItem, "Agregar", "Guardar", true)
       }
 
   return (

--- a/src/components/UI/Tables/Modals/teamModals.js
+++ b/src/components/UI/Tables/Modals/teamModals.js
@@ -13,7 +13,11 @@ import {
     InputLabel,
     //
     FormControl,
-    Autocomplete
+    Autocomplete,
+    //
+    RadioGroup,
+    Radio,
+    FormControlLabel
 } from "@mui/material";
 import Grid from "@mui/material/Grid";
 import AddIcon from "@mui/icons-material/Add";
@@ -45,8 +49,8 @@ export const TeamModals = ({
   
 }) => {
 
-      const [editedItem, setEditedItem] = useState({});          
-      const [newItem, setNewItem] = useState({students: []});    
+      const [editedItem, setEditedItem] = useState({});    
+      const [newItem, setNewItem] = useState({students: []});
       // Esto hace de handle open edit
       useEffect(() => {
         if (!openEditModal) return;
@@ -59,6 +63,8 @@ export const TeamModals = ({
 
       const [editLoading, setEditLoading] = useState(false);
       const [confirmLoading, setConfirmLoading] = useState(false);
+
+      const [topicMoveDecision, setTopicMoveDecision] = useState(null);
 
       // To-Do: Estas funciones deberían ser importables
       // Función para obtener el nombre del topic por su id
@@ -344,8 +350,9 @@ export const TeamModals = ({
             </DialogTitle>
             <form
               onSubmit={ async (e) => {
-                e.preventDefault(); // previene el reload del form                
-
+                e.preventDefault(); // previene el reload del form                           
+                
+                if (!topicMoveDecision) return;
                 if (confirmLoading) return;
                 setConfirmLoading(true);
                 try {                  
@@ -353,7 +360,9 @@ export const TeamModals = ({
                   //handleCloseModal();
                   // undefined xq no necesitamos que ese handle cierre ningún modal, ya lo cerramos recién
                   
-                  // El true llega hasta la api call y confirma los conflictos! :)
+                  // Obtenemos el bool según la decisión de quitar o conservar
+                  const moveTopic = topicMoveDecision === "remove";
+                  // El true llega hasta la api call y confirma los conflictos! :) [AUX: HAY QUE USAR EL MOVETOPIC OBVIAMENTE]
                   await handleActionToConfirm(item, setItem, handleCloseModal, true);
                 } finally {
                   setConfirmLoading(false);
@@ -376,6 +385,15 @@ export const TeamModals = ({
                   </div>
                 )}
 
+                {conflicts?.msg?.empty_delete_team && (<div>
+                  <h4>Equipo vacío</h4>
+                  <ul>
+                      <li>Se desasignarán todos los integrantes de este equipo</li>                    
+                  </ul>
+                  Confirmar desasignará todos los integrantes de este equipo y eliminará el equipo.
+                </div>
+                )}
+
                 {conflicts?.msg?.topic_conflicts?.length > 0 && (
                   <div>
                     <h4>Tema</h4>                    
@@ -384,17 +402,25 @@ export const TeamModals = ({
                         <li key={index}>{conflict_error} {getTopicNameById(item.topic?.id)}</li>
                       ))}
                     </ul>
-                    Confirmar eliminará el tema de su actual equipo y lo asignará a este equipo.
+                    Confirmar asignará el tema a este equipo, y debería ¿quitarlo de su otro equipo o conservarlo también en su otro equipo?
+                    <RadioGroup
+                      value={topicMoveDecision}
+                      onChange={(e) => setTopicMoveDecision(e.target.value)}
+                    >
+                      <FormControlLabel
+                        value="remove"
+                        control={<Radio />}
+                        label="Quitar"
+                      />
+                      <FormControlLabel
+                        value="keep"
+                        control={<Radio />}
+                        label="Conservar"
+                      />
+                    </RadioGroup>
+                    {!topicMoveDecision && 
+                      <p style={{ color: "red" }}>Se debe seleccionar una opción sobre conflicto de tema.</p>}
                   </div>
-                )}
-
-                {conflicts?.msg?.empty_delete_team && (<div>
-                  <h4>Equipo vacío</h4>
-                  <ul>
-                      <li>Se desasignarán todos los integrantes de este equipo</li>                    
-                  </ul>
-                  Confirmar desasignará todos los integrantes de este equipo y eliminará el equipo.
-                </div>
                 )}
                 
                 <p><strong>¿Confirmar?</strong></p>

--- a/src/components/UI/Tables/Modals/teamModals.js
+++ b/src/components/UI/Tables/Modals/teamModals.js
@@ -64,7 +64,7 @@ export const TeamModals = ({
       const [editLoading, setEditLoading] = useState(false);
       const [confirmLoading, setConfirmLoading] = useState(false);
 
-      const [topicMoveDecision, setTopicMoveDecision] = useState(null);
+      const [topicMoveDecision, setTopicMoveDecision] = useState(undefined);
 
       // To-Do: Estas funciones deberían ser importables
       // Función para obtener el nombre del topic por su id
@@ -303,6 +303,7 @@ export const TeamModals = ({
       const handleCloseConfirmModal = () => {
         setOpenConfirmModal(false);
         setConflictMsg({msg:[]});
+        setTopicMoveDecision(undefined);
       };
 
       const handleCloseEditModalWithoutFlushingEditedItem = () => {

--- a/src/components/UI/Tables/Modals/teamModals.js
+++ b/src/components/UI/Tables/Modals/teamModals.js
@@ -13,15 +13,21 @@ import {
     InputLabel,
     //
     FormControl,
-    Autocomplete,
+    //Autocomplete,
     //
     RadioGroup,
     Radio,
-    FormControlLabel
+    FormControlLabel,
+    //createFilterOptions
+
 } from "@mui/material";
 import Grid from "@mui/material/Grid";
 import AddIcon from "@mui/icons-material/Add";
+import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
+const filter = createFilterOptions();
+
 const CLEARSTRING = "Eliminar integrante";
+
 
 /* Modals para Agregar equipo, Editar equipo, y Confirmar la edición en caso de conflicto.
  * Puede ocasionarse conflicto sea durante el agregado o durante la edición.
@@ -182,34 +188,26 @@ export const TeamModals = ({
 
                   {/* Tema y tutor */}
                   <InputLabel>Tema y Tutor/a</InputLabel>
-                  <FormControl fullWidth variant="outlined" margin="normal">
-                      <InputLabel>Tema</InputLabel>
-                      <Select
-                        value={item.topic?.id || ""}
-                        onChange={(e) =>
-                          setItem({ ...item, topic: getTopicById(e.target.value) })
-                        }
-                        label="Tema"
-                        required
-                      >
-                        {topics.csvTopics.map((topic) => (
-                          <MenuItem
-                            key={topic.id}
-                            value={topic.id}
-                          >
-                            {topic.name}
-                          </MenuItem>
-                        ))}
+                  
+                      <Autocomplete
+                        disablePortal
+                        //options={[...topics.csvTopics, ... (!topics.csvTopics.some(t => t.id === item.topic?.id)) ? item.topic?.id : ""] || []}
+                        //options={[...topics.csvTopics, ...item.topic?? ""] || ""}
+                        options={topics.csvTopics ?? []}
+                        getOptionLabel={(option) => option?.name ?? ""} // cómo mostrar el texto
+                        sx={{ width: '100%' }}                       
 
-                        {/* Si el valor actual es un custom, agregarlo como opción (no seleccionable)
-                            para que se pueda mostrar como valor inicial al abrir el modal*/}
-                        {item.topic && !topics.csvTopics.some(t => t.id === item.topic.id) && (
-                          <MenuItem key={item.topic.id} value={item.topic.id} disabled>
-                            {item.topic.name}
-                          </MenuItem>
-                        )}
-                      </Select>
-                    </FormControl>
+                        //filterOptions={(option, params) => [option?.name ?? null]}
+
+
+                        isOptionEqualToValue={(option, value) => option?.id === value?.id} // <-- esto compara por id
+                        clearText="Desasignar tema"
+                        onChange={(event, newValue) => {
+                          setItem({ ...item, topic: newValue ?? null})
+                        }}
+                        renderInput={(params) => <TextField {...params} label="Tema"/>} // label es la etiqueta a mostrar
+                        value={item?.topic ?? null} // la opción seteada actual
+                      />                  
                   
                   <FormControl fullWidth variant="outlined" margin="normal">
                     {<InputLabel margin="normal">Tutor/a</InputLabel>

--- a/src/components/UI/Tables/Modals/teamModals.js
+++ b/src/components/UI/Tables/Modals/teamModals.js
@@ -25,7 +25,7 @@ const CLEARSTRING = "Eliminar integrante";
  * ya que el primer modal continúa en pantalla en caso de haber conflictos, y el de confirm
  * se muestra por encima, hasta que se confirme (o se cancele) la operación.
  */
-export const TeamModal = ({
+export const TeamModals = ({
   openAddModal, // bools para ver si se debe abrir cada modal
   openEditModal,
   openConfirmModal,
@@ -319,11 +319,11 @@ export const TeamModal = ({
         // Usa el editedItem, por lo que en el medio, no se debe haber flusheado editedItem (ej hay que no cerrar (desde afuera) el modal anterior si hay conflicto)
         // Además, luego de Confirmar se necesita usar desde afuera al editedItem por lo que no hay que flushearlo desde acá sino afuera
         // AUX: acá un if type es edit hacer esto, else hacer lo mismo pero para add, y hay que agregar un blablawithputFlushing para add p q ande - #saludos me voy a cenar
-        if (conflicts?.operation == "add") {
+        if (conflicts?.operation === "add") {
           
           return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseAddModalWithoutFlushingItem, handleAddItem, newItem, setNewItem, "Agregar", "Confirmar");
 
-        } else if (conflicts?.operation == "edit") {
+        } else if (conflicts?.operation === "edit") {
           return innerConfirmOnConflictModal(openConfirmModal, handleCloseConfirmModal, handleCloseEditModalWithoutFlushingEditedItem, handleEditItem, editedItem, setEditedItem, "Editar", "Confirmar");
         }
       }
@@ -464,7 +464,7 @@ export const TeamModal = ({
                                         
                       <Grid container spacing={2} sx={{ marginBottom: 2 }}>
                         <Grid item xs={12}>
-                          <Autocomplete
+                          <Autocomplete              
                             disablePortal
                             options={students || []}
                             getOptionLabel={(option) => option.id? `${option.id} - ${option.name} ${option.last_name}` : ""} // cómo mostrar el texto

--- a/src/components/UI/Tables/Modals/teamModals.js
+++ b/src/components/UI/Tables/Modals/teamModals.js
@@ -362,8 +362,8 @@ export const TeamModals = ({
                   
                   // Obtenemos el bool según la decisión de quitar o conservar
                   const moveTopic = topicMoveDecision === "remove";
-                  // El true llega hasta la api call y confirma los conflictos! :) [AUX: HAY QUE USAR EL MOVETOPIC OBVIAMENTE]
-                  await handleActionToConfirm(item, setItem, handleCloseModal, true);
+                  // El true llega hasta la api call y confirma los conflictos! :)
+                  await handleActionToConfirm(item, setItem, handleCloseModal, true, moveTopic);
                 } finally {
                   setConfirmLoading(false);
                 }

--- a/src/components/UI/Tables/Modals/teamModals.js
+++ b/src/components/UI/Tables/Modals/teamModals.js
@@ -683,6 +683,26 @@ export const TeamModals = ({
                   {/* Las tres preferencias, no editables - resulta ser que sí las queremos editables []
                     * No irán a este endpoint de add_team, es otro endpoint el de las answers.
                   */}
+                  {/*
+                  <InputLabel>Preferencias</InputLabel>
+                  <TextField
+                    variant="outlined"
+                    fullWidth
+                    margin="normal"
+                    label="Preferencia 1"
+                    value={item?.preferred_topics?.[0] ?? ""}
+                    disabled={false}
+                    onChange={(e) => {
+                      const newPreferredTopics = item.preferred_topics ? [...item.preferred_topics] : [];
+                      if (e.target.value) {
+                        newPreferredTopics[0] = e.target.value;
+                      } else {
+                        newPreferredTopics[0] = null // dejarlo vacío al quitar la selección
+                      }
+                      setItem({ ...item, preferred_topics: newPreferredTopics });
+                    }}
+                  />
+                   */}
                  
                   </Grid>
 


### PR DESCRIPTION
# Agregar equipo, desde rol admin - y mejoras sobre Editar equipo

La funcionalidad nueva y cambios funcionales están explicados en el PR del back.

- **se agrega el botón de Agregar equipo a la tabla de Equipos, con todo su flujo hasta la api call.**
- luego de la api call, **se adapta la lista inmediatamente con los resultados**. Para esto se generaliza y reutiliza una función que se usaba luego de editar.

- **se reutiliza el modal de conflictos, que se usaba en la edición, ahora también para add equipo.** Para esto se agrega un campo operation, para ver si fue conflicto durante el add o durante el edit.

Se contemplan las dos minifeatures explicadas en PR del back:
- modal de conflictos en sección conflicto de temas, **ahora da la opción a admin de quitar el tema de los demás equipos en conflicto o conservarlo**. Esto incluye el manejo del nuevo _estadito_ y condición (no permite continuar hasta que admin indique si desea quitar o conservar, de darse ese conflicto).

- para poder crear un tema al agregar/editar equipo, primero habría que buscarlo entre los existentes.
   - Como era algo tedioso buscar "a ojo" en un dropdown (se llama "Select"), **se migró de Select a Autocomplete**. El autocomplete lo que tiene de bueno es **que** podés tipear y funciona como buscar, te **muestra las coincidencias**.
   - luego de eso, se agregó lo necesario a **ese Autocomplete** y **ahora permite "Crear un tema"**, es decir, que el tipeo que usualmente es para buscar, también funcione para crear el tema como si fuera un campo de texto libre y con una leyenda para que quede claro que se creará el tema.

   - copypaste de **eso mismo del autocomplete al modal de add**, xq es de día ya y no quiero romper cosas sin querer generalizando con sueño, xd.

   Esto quiere decir que **se puede crear un tema tanto desde el modal de add equipo como desde el de editar equipo**.

Issue: tpf-v2/assignment-service#209.