### PR TITLE
Feat/pre check tmb disp de tutores

### DIFF
--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -87,16 +87,25 @@ export const AlgorithmPreCheck = ({
               </Typography>
             </Grid>
           ))}
-          {/* Si hay gente que falte al input, y aplique mostrar, muestro botón para ver quiénes son en modal */}
-          {areThereProblems && condition && (          
-            <Typography variant="body1" sx={{ textAlign: "justify" }}>
-              <Button
-                variant="outlined"                
-                onClick={() => {setData(dataWithIcons); setOpen(true)}}
-              >
-                Analizar
-              </Button>
-            </Typography>
+          {/* Si hay gente que falte al input, y aplica mostrar, muestro botón para ver quiénes son en modal */}
+          {areThereProblems && condition && (    
+            <Grid
+              item
+              xs={12}
+              md={falseConditionMsg ? 12 : 11}
+              sx={{ display: "flex", justifyContent: "right" }}
+            >
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={() => {setData(dataWithIcons); setOpen(true)}}
+              sx={{ ml: "auto", mt: "auto",
+                padding: falseConditionMsg ? "6px 19px" : "6px 9px", // Tamaño del botón para coincidir visualmente con el de "Correr"
+               }} // ml empuja hacia la derecha (al gap lo maneja el último de la derecha)
+            >
+              Analizar
+            </Button> 
+            </Grid>           
           )}
           </>
       ) : (

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -14,11 +14,6 @@ const AlgorithmPreCheck = ({
   const [open, setOpen] = useState(false);
   const [data, setData] = useState();
 
-  // // Aux tutores mientras pruebo
-  let showWhoComponentTutors;
-  let showWhoListTutors;
-  let msgTutors;
-
   return (
     <>
     <Grid item xs={12} md={12} sx={{ display: "flex" }}>
@@ -45,60 +40,37 @@ const AlgorithmPreCheck = ({
       </Grid>
 
       {condition ? (
-        <>          
+        <>
+        {/* Muestro lista de cada msj (ej "Existen _n_ ... que no ...", o msj de Todo ok) con su ícono*/}
+          {expandableData?.map((okMsgOrProblematicEntity) => (
             <>
-              <Grid item xs={12} md={12} sx={{ display: "flex", gap: 0.5}}>  
-                {checkResultIcon}
-                <Typography variant="body1" sx={{ textAlign: "justify" }}>
-                  <strong>{expandableData[0].title}</strong>
-                </Typography>
-              </Grid>
-
-              {/* Va éste. y hay que reutilizar cosas acá, el "inputInfo" es lo variable */}
-              {/*inputInfo.length > 0 && condition && (*/}
-              {expandableData[0].infoList.length > 0 && condition && (
-                <Typography variant="body1" sx={{ textAlign: "justify" }}>
-                  <Button
-                    variant="outlined"
-                    onClick={() => {setData(expandableData); setOpen(true)}}
-                  >
-                    Analizar
-                  </Button>
-
-                </Typography>
-              )}
-            </>
-          
-            <>
-              {/* Tutores - fechas */}
-              <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
-                <Typography variant="body1" sx={{ textAlign: "justify" }}>
-                  <strong>{msgTutors}</strong>
-                </Typography>
-              </Grid>              
-
-               {/* Va éste. veamosssssssss _ en realidad no del todo pero probando __ y hay que reutilizar cosas acá, el "inputInfo" es lo variable */}
-               {inputInfo.teachers?.length > 0 && condition && (
-                <Typography variant="body1" sx={{ textAlign: "justify" }}>
-                  <Button
-                    variant="outlined"
-                    onClick={() => {setData(expandableData); setOpen(true)}}
-                  >
-                    Analizar
-                  </Button>
-
-                </Typography>
-              )}
-            
-            </>
-        </>
+            <Grid item xs={12} md={12} sx={{ display: "flex", gap: 0.5}}>  
+              {checkResultIcon}
+              <Typography variant="body1" sx={{ textAlign: "justify" }}>
+                <strong>{okMsgOrProblematicEntity.title}</strong>
+              </Typography>
+            </Grid>
+          {/* Si hay gente que falte al input, y aplique mostrar, muestro botón para ver quiénes son en modal */}
+          {okMsgOrProblematicEntity.infoList.length > 0 && condition && (
+            <Typography variant="body1" sx={{ textAlign: "justify" }}>
+              <Button
+                variant="outlined"
+                onClick={() => {setData(expandableData); setOpen(true)}}
+              >
+                Analizar
+              </Button>
+            </Typography>
+          )}
+           </>
+          ))}
+          </>
       ) : (
-          
-          <Grid item xs={12} md={12} sx={{ display: "flex", gap: 0.5 }}>
-            {checkResultIcon}
-            {falseConditionMsg}
-          </Grid>
-          )
+        <Grid item xs={12} md={12} sx={{ display: "flex", gap: 0.5 }}>
+          {/* Si esto es false, no aplica mostrarlos xq existe otro problema ("primero admin cargar fechas")*/}
+          {checkResultIcon}
+          {falseConditionMsg}
+        </Grid>
+      )
       }      
       </>
     )}

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Grid, Typography, Link } from "@mui/material";
+import { Grid, Typography, Link, Box, CircularProgress } from "@mui/material";
 import StudentsTable from "../UI/Tables/ChildTables/StudentsTable";
 import TeamsTable from "../UI/Tables/ChildTables/GroupsTable";
 import TutorsTable from "../UI/Tables/ChildTables/TutorsTable";
@@ -75,6 +75,16 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
         Verificación previa
       </Typography>
     </Grid>
+    {!inputInfo && (
+      <Grid item xs={12} md={12} sx={{ display: "flex" }}>
+        <Box
+          display="flex"
+          minHeight="300px"
+        >
+          <CircularProgress />
+        </Box>
+      </Grid>
+    )}
     {inputInfo && (
       <>
       <Grid item xs={12} md={12} sx={{ display: "flex" }}>

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -2,17 +2,11 @@ import React, {useState} from "react";
 import { Grid, Typography, Link, Box, CircularProgress,
          Dialog, Button, DialogTitle, DialogContent,
          Accordion, AccordionSummary, AccordionDetails, } from "@mui/material";
-import StudentsTable from "../UI/Tables/ChildTables/StudentsTable";
-import TeamsTable from "../UI/Tables/ChildTables/GroupsTable";
-import TutorsTable from "../UI/Tables/ChildTables/TutorsTable";
-
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import WarningAmberIcon from '@mui/icons-material/WarningAmber';
-import ErrorIcon from "@mui/icons-material/Error";
 
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
-const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu,
+const AlgorithmPreCheck = ({
+  initialDescription, inputInfo, algorithm, setSelectedMenu,
   msg, showWhoComponent, showWhoList, condition, checkResultIcon, expandableData,
   falseConditionMsg
 }) => {  
@@ -20,102 +14,10 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
   const [open, setOpen] = useState(false);
   const [data, setData] = useState();
 
-  // let msg;
-  // let showWhoComponent;
-  // let showWhoList;
-
   // // Aux tutores mientras pruebo
   let showWhoComponentTutors;
   let showWhoListTutors;
   let msgTutors;
-
-  // let condition = true;
-
-  // let checkResultIcon;
-
-  // let expandableData;
-
-  switch (algorithm) {
-    case "IncompleteTeams": {
-
-    //   if (inputInfo && condition!==undefined) {
-
-    //     msg = inputInfo.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
-    //     : inputInfo.length === 1 ? "Existe 1 estudiante que no está en respuestas al formulario de equipos en ninguna de sus variantes"
-    //     : `Existen ${inputInfo.length} estudiantes que no están en respuestas al formulario de equipos en ninguna de sus variantes`
-  
-    //     showWhoList = inputInfo;
-    //     showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
-
-    //     expandableData = [{title: msg, detail: showWhoComponent}]
-  
-    //     // "condition" queda en true (ponerle un mejor nombre)
-
-    //     // Ícono
-    //     checkResultIcon = inputInfo.length === 0
-    //     ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>
-        
-    //     if (!condition) {
-    //       checkResultIcon = <ErrorIcon color="error"/>
-    //     }
-
-    //   }
-
-      break;
-    }
-    case "Dates": {  
-
-      // if (inputInfo) {
-        
-      //   condition = inputInfo.admin_slots;
-        
-      //   msg =
-      //     inputInfo.teams?.length === 0 ? "Todos los equipos completaron su disponibilidad."
-      //     : inputInfo.teams?.length === 1 ? "Existe 1 equipo que no completó su disponibilidad"
-      //     : `Existen ${inputInfo.teams?.length} equipos que no completaron su disponibilidad`
-        
-      //   showWhoList = inputInfo.teams;
-      //   showWhoComponent = <TeamsTable dataListToRender={showWhoList} />;
-
-
-      //   // Ícono
-      //   checkResultIcon = inputInfo.length === 0
-      //   ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>
-        
-      //   if (!condition) {
-      //     checkResultIcon = checkResultIcon = <ErrorIcon color="error"/>
-      //   }
-
-      //   //////////
-      //   // Tutores
-      //   const showWhoListTutors = inputInfo.teachers;
-      //   const showWhoComponentTutors = <TutorsTable dataListToRender={showWhoListTutors} />;      
-      //   const msgTutors = 
-      //     inputInfo.teachers?.length === 0 ? "Todos/as los/as tutores/as completaron su disponibilidad."
-      //     : inputInfo.teachers?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad"
-      //     : `Existen ${inputInfo.teachers?.length} tutores/as que no completaron su disponibilidad`      
-      // }
-      
-
-
-      // expandableData = [{title: msg, detail: showWhoComponent},
-      //                   {title: msgTutors, detail: showWhoComponentTutors}
-      // ]
-      // if (!setSelectedMenu) return;
-      
-      break;
-    }
-    default: {
-      console.log("Error, valor no esperado de algorithm:", algorithm);
-      msg = "Ocurrió un error inesperado al mostrar información";
-    }
-  }
-
-  // Nop, esto siempre da true -_-
-  // if (condition === undefined) {
-  //   return
-  // }
-  console.log("--- condition:", condition);
 
   return (
     <>
@@ -236,7 +138,3 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
 }
 
 export default AlgorithmPreCheck;
-
-    // <Grid item xs={12} md={12} sx={{ display: "flex" }}>
-    //   {showWhoComponent}
-    // </Grid>

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -1,6 +1,7 @@
 import React, {useState} from "react";
 import { Grid, Typography, Link, Box, CircularProgress,
-         Dialog, Button } from "@mui/material";
+         Dialog, Button, DialogTitle, DialogContent,
+         Accordion, AccordionSummary, AccordionDetails, } from "@mui/material";
 import StudentsTable from "../UI/Tables/ChildTables/StudentsTable";
 import TeamsTable from "../UI/Tables/ChildTables/GroupsTable";
 import TutorsTable from "../UI/Tables/ChildTables/TutorsTable";
@@ -8,6 +9,8 @@ import TutorsTable from "../UI/Tables/ChildTables/TutorsTable";
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import ErrorIcon from "@mui/icons-material/Error";
+
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {  
   //if (!inputInfo) return;
@@ -28,17 +31,21 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
 
   let checkResultIcon;
 
+  let expandableData;
+
   switch (algorithm) {
     case "IncompleteTeams": {
 
       if (inputInfo) {
 
         msg = inputInfo.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
-        : inputInfo.length === 1 ? "Existe 1 estudiante que no está en respuestas al formulario de equipos en ninguna de sus variantes:"
-        : `Existen ${inputInfo.length} estudiantes que no están en respuestas al formulario de equipos en ninguna de sus variantes:`
+        : inputInfo.length === 1 ? "Existe 1 estudiante que no está en respuestas al formulario de equipos en ninguna de sus variantes"
+        : `Existen ${inputInfo.length} estudiantes que no están en respuestas al formulario de equipos en ninguna de sus variantes`
   
         showWhoList = inputInfo;
         showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
+
+        //expandableData = {title: "Estudiantes " } //no, es directamente msg
   
         // "condition" queda en true (ponerle un mejor nombre)
 
@@ -68,8 +75,6 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
         showWhoList = inputInfo.teams;
         showWhoComponent = <TeamsTable dataListToRender={showWhoList} />;
 
-        checkResultIcon = inputInfo.teams?.length === 0
-        ? <CheckCircleIcon /> : <WarningAmberIcon />
 
         // Ícono
         checkResultIcon = inputInfo.length === 0
@@ -132,19 +137,20 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
                 <Typography variant="body1" sx={{ textAlign: "justify" }}>
                   <strong>{msg}</strong>
                 </Typography>
-              </Grid>              
+              </Grid>
 
+              {/* Éste no va */}
               {false && showWhoList?.length > 0 && (
                 <Grid item xs={12} md={12} sx={{ display: "flex" }}>
                   {showWhoComponent}
                 </Grid>
               )}
-
+              {/* Va éste. y hay que reutilizar cosas acá, el "inputInfo" es lo variable */}
               {inputInfo.length > 0 && condition && (
                 <Typography variant="body1" sx={{ textAlign: "justify" }}>
                   <Button
                     variant="outlined"
-                    onClick={() => {setData(showWhoList); setOpen(true)}}
+                    onClick={() => {setData([{title: msg, detail: showWhoComponent}]); setOpen(true)}}
                   >
                     Ver quiénes
                   </Button>
@@ -190,9 +196,22 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
 
 
   <Dialog open={open} onClose={() => {setOpen(false)}} maxWidth={false} fullWidth>
-    <Grid item xs={12} md={12} sx={{ display: "flex" }}>
-      {showWhoComponent}
-    </Grid>
+    <DialogTitle>Entidades con problemas</DialogTitle>
+    <DialogContent>
+      {data?.map((e, index) => (
+        <Accordion key={index} defaultExpanded={false}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography>
+              {e.title}
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Typography variant="body2">{e.detail}</Typography>
+          </AccordionDetails>
+        </Accordion>
+      ))}
+    </DialogContent>
+          
   </Dialog>
 
   </>
@@ -200,3 +219,7 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
 }
 
 export default AlgorithmPreCheck;
+
+    // <Grid item xs={12} md={12} sx={{ display: "flex" }}>
+    //   {showWhoComponent}
+    // </Grid>

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -15,8 +15,12 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
   let showWhoComponentTutors;
   let showWhoListTutors;
   let msgTutors;
+
+  let condition = true;
+
   switch (algorithm) {
     case "IncompleteTeams": {
+
       msg = inputInfo.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
       : inputInfo.length === 1 ? "Existe 1 estudiante que no está en respuestas al formulario de equipos en ninguna de sus variantes:"
       : `Existen ${inputInfo.length} estudiantes que no están en respuestas al formulario de equipos en ninguna de sus variantes:`
@@ -24,52 +28,30 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
       showWhoList = inputInfo;
       showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
 
+      // "condition" queda en true (ponerle un mejor nombre)
+
       break;
     }
     case "Dates": {
       if (!setSelectedMenu) return;
+
+      condition = inputInfo.admin_slots;
       
-      msg = inputInfo.admin_slots ? (
+      msg =
         inputInfo.teams?.length === 0 ? "Todos los equipos completaron su disponibilidad."
         : inputInfo.teams?.length === 1 ? "Existe 1 equipo que no completó su disponibilidad:"
         : `Existen ${inputInfo.teams?.length} equipos que no completaron su disponibilidad:`
-      ) : (
-        <>
-          Primero se debe cargar las fechas disponibles desde la sección {""}
-          <Link
-            component="span"
-            onClick={() => setSelectedMenu("Disponibilidad fechas de Presentación")}
-            underline="always"
-            sx={{ color: "blue", cursor: "pointer"}}
-            >
-            Disponibilidad fechas de Presentación
-          </Link>.
-        </>
-        )
       
       showWhoList = inputInfo.teams;
       showWhoComponent = <TeamsTable dataListToRender={showWhoList} />;
-      
+
       // Tutores
       showWhoListTutors = inputInfo.teachers;
       showWhoComponentTutors = <TutorsTable dataListToRender={showWhoListTutors} />;      
-      msgTutors = inputInfo.admin_slots ? (
-        inputInfo.teachers?.length === 0 ? "Todos los tutores/as completaron su disponibilidad."
+      msgTutors = 
+        inputInfo.teachers?.length === 0 ? "Todos/as los/as tutores/as completaron su disponibilidad."
         : inputInfo.teachers?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad:"
-        : `Existen ${inputInfo.teachers?.length} tutoras/es que no completaron su disponibilidad:`
-      ) : ( // cambiar esta estructura de ifs xq no quiero dar dos veces este msj de abajo, va ese chack primero
-        <>
-          Primero se debe cargar las fechas disponibles desde la sección {""}
-          <Link
-            component="span"
-            onClick={() => setSelectedMenu("Disponibilidad fechas de Presentación")}
-            underline="always"
-            sx={{ color: "blue", cursor: "pointer"}}
-            >
-            Disponibilidad fechas de Presentación
-          </Link>.
-        </>
-        )
+        : `Existen ${inputInfo.teachers?.length} tutores/as que no completaron su disponibilidad:`      
       
       break;
     }
@@ -94,33 +76,51 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
         </Typography>
       </Grid>
 
-      <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
-        <Typography variant="body1" sx={{ textAlign: "justify" }}>
-          {msg}
-        </Typography>
-      </Grid>      
+      {condition ? (
+        <>          
+            <>
+              <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
+                <Typography variant="body1" sx={{ textAlign: "justify" }}>
+                  {msg}
+                </Typography>
+              </Grid>      
 
-      {showWhoList.length > 0 && (
-        <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
-          {showWhoComponent}
-        </Grid>)
-      }
-
-      {/* Tutores - fechas */}
-      {showWhoListTutors.length > 0 && (
-        <>
-        <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
-          <Typography variant="body1" sx={{ textAlign: "justify" }}>
-            {msgTutors}
-          </Typography>
-        </Grid>
-        <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
-          {showWhoComponentTutors}
-        </Grid>
+              {showWhoList?.length > 0 && (
+                <Grid item xs={12} md={12} sx={{ display: "flex" }}>
+                  {showWhoComponent}
+                </Grid>
+              )}
+            </>
+          
+            <>
+              {/* Tutores - fechas */}
+              <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
+                <Typography variant="body1" sx={{ textAlign: "justify" }}>
+                  {msgTutors}
+                </Typography>
+              </Grid>
+              {showWhoListTutors?.length > 0 && (
+                <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
+                  {showWhoComponentTutors}
+                </Grid>
+              )}
+            </>
         </>
-        )
-      }
-
+      ) : (
+          
+          <Grid item xs={12} md={12} sx={{ display: "flex" }}>
+            Primero se debe cargar las fechas disponibles desde la sección {""}
+            <Link
+              component="span"
+              onClick={() => setSelectedMenu("Disponibilidad fechas de Presentación")}
+              underline="always"
+              sx={{ color: "blue", cursor: "pointer"}}
+              >
+              Disponibilidad fechas de Presentación
+            </Link>.
+          </Grid>
+          )
+      }      
       </>
     )}
   </>

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -1,5 +1,5 @@
 import React, {useState} from "react";
-import { Grid, Typography, Box, CircularProgress,
+import { Grid, Typography, CircularProgress, Box,
          Dialog, Button, DialogTitle, DialogContent,
          Accordion, AccordionSummary, AccordionDetails } from "@mui/material";
 
@@ -9,7 +9,34 @@ import ErrorIcon from "@mui/icons-material/Error";
 
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
-const AlgorithmPreCheck = ({
+// Componente auxiliar para mostrar el título con el spinner mientras carga
+export const Title = ({withSpinner=false}) => {
+  const spinner = () => (
+    <Grid item xs={12} md={12} sx={{ display: "flex" }}>
+      <Box
+        display="flex"
+        minHeight="300px"
+      >
+        <CircularProgress />
+      </Box>
+    </Grid>
+  )
+
+  return (
+    <>
+      <Grid item xs={12} md={12} sx={{ display: "flex" }}>
+        <Typography variant="h5" sx={{ fontWeight: "bold" }}>
+          Verificación previa
+        </Typography>      
+      </Grid>
+      {withSpinner && (
+        spinner()
+      )}
+    </>
+  )
+}
+
+export const AlgorithmPreCheck = ({
   initialDescription,
   condition=true,
   expandableData,
@@ -36,21 +63,7 @@ const AlgorithmPreCheck = ({
 
   return (
     <>
-    <Grid item xs={12} md={12} sx={{ display: "flex" }}>
-      <Typography variant="h5" sx={{ fontWeight: "bold" }}>
-        Verificación previa
-      </Typography>
-    </Grid>
-    {!expandableData && (
-      <Grid item xs={12} md={12} sx={{ display: "flex" }}>
-        <Box
-          display="flex"
-          minHeight="300px"
-        >
-          <CircularProgress />
-        </Box>
-      </Grid>
-    )}
+    <Title />    
     {dataWithIcons && (
       <>
       <Grid item xs={12} md={12} sx={{ display: "flex" }}>
@@ -116,5 +129,3 @@ const AlgorithmPreCheck = ({
   </>
 );
 }
-
-export default AlgorithmPreCheck;

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -1,7 +1,8 @@
 import React, {useState} from "react";
 import { Grid, Typography, CircularProgress, Box,
          Dialog, Button, DialogTitle, DialogContent,
-         Accordion, AccordionSummary, AccordionDetails } from "@mui/material";
+         Accordion, AccordionSummary, AccordionDetails, 
+         DialogActions} from "@mui/material";
 
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
@@ -136,6 +137,11 @@ export const AlgorithmPreCheck = ({
         </Accordion>
       ))}
     </DialogContent>
+    <DialogActions>
+      <Button onClick={() => {setOpen(false)}} variant="contained" color="primary">
+          Cerrar
+      </Button>
+    </DialogActions>
           
   </Dialog>
 

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -13,7 +13,6 @@ import ErrorIcon from "@mui/icons-material/Error";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {  
-  //if (!inputInfo) return;
 
   const [open, setOpen] = useState(false);
   const [data, setData] = useState();
@@ -45,7 +44,7 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
         showWhoList = inputInfo;
         showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
 
-        //expandableData = {title: "Estudiantes " } //no, es directamente msg
+        expandableData = [{title: msg, detail: showWhoComponent}]
   
         // "condition" queda en true (ponerle un mejor nombre)
 
@@ -90,10 +89,15 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
         showWhoComponentTutors = <TutorsTable dataListToRender={showWhoListTutors} />;      
         msgTutors = 
           inputInfo.teachers?.length === 0 ? "Todos/as los/as tutores/as completaron su disponibilidad."
-          : inputInfo.teachers?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad:"
-          : `Existen ${inputInfo.teachers?.length} tutores/as que no completaron su disponibilidad:`      
+          : inputInfo.teachers?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad"
+          : `Existen ${inputInfo.teachers?.length} tutores/as que no completaron su disponibilidad`      
       }
       
+
+
+      expandableData = [{title: msg, detail: showWhoComponent},
+                        {title: msgTutors, detail: showWhoComponentTutors}
+      ]
       if (!setSelectedMenu) return;
       
       break;
@@ -150,9 +154,9 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
                 <Typography variant="body1" sx={{ textAlign: "justify" }}>
                   <Button
                     variant="outlined"
-                    onClick={() => {setData([{title: msg, detail: showWhoComponent}]); setOpen(true)}}
+                    onClick={() => {setData(expandableData); setOpen(true)}}
                   >
-                    Ver quiénes
+                    Analizar
                   </Button>
 
                 </Typography>
@@ -166,11 +170,25 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
                   <strong>{msgTutors}</strong>
                 </Typography>
               </Grid>
-              {showWhoListTutors?.length > 0 && (
+              {false && showWhoListTutors?.length > 0 && (
                 <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
                   {showWhoComponentTutors}
                 </Grid>
               )}
+
+               {/* Va éste. veamosssssssss _ en realidad no del todo pero probando __ y hay que reutilizar cosas acá, el "inputInfo" es lo variable */}
+               {inputInfo.teachers?.length > 0 && condition && (
+                <Typography variant="body1" sx={{ textAlign: "justify" }}>
+                  <Button
+                    variant="outlined"
+                    onClick={() => {setData(expandableData); setOpen(true)}}
+                  >
+                    Analizar
+                  </Button>
+
+                </Typography>
+              )}
+            
             </>
         </>
       ) : (
@@ -195,14 +213,14 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
     )}
 
 
-  <Dialog open={open} onClose={() => {setOpen(false)}} maxWidth={false} fullWidth>
+  <Dialog open={open} onClose={() => {setOpen(false)}} maxWidth={false}>
     <DialogTitle>Entidades con problemas</DialogTitle>
     <DialogContent>
       {data?.map((e, index) => (
         <Accordion key={index} defaultExpanded={false}>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
             <Typography>
-              {e.title}
+              <strong>{e.title}</strong>
             </Typography>
           </AccordionSummary>
           <AccordionDetails>

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -5,7 +5,7 @@ import TeamsTable from "../UI/Tables/ChildTables/GroupsTable";
 import TutorsTable from "../UI/Tables/ChildTables/TutorsTable";
 
 const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {  
-  if (!inputInfo) return;
+  //if (!inputInfo) return;
 
   let msg;
   let showWhoComponent;
@@ -21,37 +21,44 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
   switch (algorithm) {
     case "IncompleteTeams": {
 
-      msg = inputInfo.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
-      : inputInfo.length === 1 ? "Existe 1 estudiante que no está en respuestas al formulario de equipos en ninguna de sus variantes:"
-      : `Existen ${inputInfo.length} estudiantes que no están en respuestas al formulario de equipos en ninguna de sus variantes:`
+      if (inputInfo) {
 
-      showWhoList = inputInfo;
-      showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
-
-      // "condition" queda en true (ponerle un mejor nombre)
+        msg = inputInfo.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
+        : inputInfo.length === 1 ? "Existe 1 estudiante que no está en respuestas al formulario de equipos en ninguna de sus variantes:"
+        : `Existen ${inputInfo.length} estudiantes que no están en respuestas al formulario de equipos en ninguna de sus variantes:`
+  
+        showWhoList = inputInfo;
+        showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
+  
+        // "condition" queda en true (ponerle un mejor nombre)
+      }
 
       break;
     }
-    case "Dates": {
+    case "Dates": {      
+
+      if (inputInfo) {
+        
+        condition = inputInfo.admin_slots;
+        
+        msg =
+          inputInfo.teams?.length === 0 ? "Todos los equipos completaron su disponibilidad."
+          : inputInfo.teams?.length === 1 ? "Existe 1 equipo que no completó su disponibilidad:"
+          : `Existen ${inputInfo.teams?.length} equipos que no completaron su disponibilidad:`
+        
+        showWhoList = inputInfo.teams;
+        showWhoComponent = <TeamsTable dataListToRender={showWhoList} />;
+  
+        // Tutores
+        showWhoListTutors = inputInfo.teachers;
+        showWhoComponentTutors = <TutorsTable dataListToRender={showWhoListTutors} />;      
+        msgTutors = 
+          inputInfo.teachers?.length === 0 ? "Todos/as los/as tutores/as completaron su disponibilidad."
+          : inputInfo.teachers?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad:"
+          : `Existen ${inputInfo.teachers?.length} tutores/as que no completaron su disponibilidad:`      
+      }
+      
       if (!setSelectedMenu) return;
-
-      condition = inputInfo.admin_slots;
-      
-      msg =
-        inputInfo.teams?.length === 0 ? "Todos los equipos completaron su disponibilidad."
-        : inputInfo.teams?.length === 1 ? "Existe 1 equipo que no completó su disponibilidad:"
-        : `Existen ${inputInfo.teams?.length} equipos que no completaron su disponibilidad:`
-      
-      showWhoList = inputInfo.teams;
-      showWhoComponent = <TeamsTable dataListToRender={showWhoList} />;
-
-      // Tutores
-      showWhoListTutors = inputInfo.teachers;
-      showWhoComponentTutors = <TutorsTable dataListToRender={showWhoListTutors} />;      
-      msgTutors = 
-        inputInfo.teachers?.length === 0 ? "Todos/as los/as tutores/as completaron su disponibilidad."
-        : inputInfo.teachers?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad:"
-        : `Existen ${inputInfo.teachers?.length} tutores/as que no completaron su disponibilidad:`      
       
       break;
     }

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -1,5 +1,6 @@
-import React from "react";
-import { Grid, Typography, Link, Box, CircularProgress } from "@mui/material";
+import React, {useState} from "react";
+import { Grid, Typography, Link, Box, CircularProgress,
+         Dialog, Button } from "@mui/material";
 import StudentsTable from "../UI/Tables/ChildTables/StudentsTable";
 import TeamsTable from "../UI/Tables/ChildTables/GroupsTable";
 import TutorsTable from "../UI/Tables/ChildTables/TutorsTable";
@@ -10,6 +11,9 @@ import ErrorIcon from "@mui/icons-material/Error";
 
 const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {  
   //if (!inputInfo) return;
+
+  const [open, setOpen] = useState(false);
+  const [data, setData] = useState();
 
   let msg;
   let showWhoComponent;
@@ -58,8 +62,8 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
         
         msg =
           inputInfo.teams?.length === 0 ? "Todos los equipos completaron su disponibilidad."
-          : inputInfo.teams?.length === 1 ? "Existe 1 equipo que no completó su disponibilidad:"
-          : `Existen ${inputInfo.teams?.length} equipos que no completaron su disponibilidad:`
+          : inputInfo.teams?.length === 1 ? "Existe 1 equipo que no completó su disponibilidad"
+          : `Existen ${inputInfo.teams?.length} equipos que no completaron su disponibilidad`
         
         showWhoList = inputInfo.teams;
         showWhoComponent = <TeamsTable dataListToRender={showWhoList} />;
@@ -128,12 +132,24 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
                 <Typography variant="body1" sx={{ textAlign: "justify" }}>
                   <strong>{msg}</strong>
                 </Typography>
-              </Grid>      
+              </Grid>              
 
-              {showWhoList?.length > 0 && (
+              {false && showWhoList?.length > 0 && (
                 <Grid item xs={12} md={12} sx={{ display: "flex" }}>
                   {showWhoComponent}
                 </Grid>
+              )}
+
+              {inputInfo.length > 0 && condition && (
+                <Typography variant="body1" sx={{ textAlign: "justify" }}>
+                  <Button
+                    variant="outlined"
+                    onClick={() => {setData(showWhoList); setOpen(true)}}
+                  >
+                    Ver quiénes
+                  </Button>
+
+                </Typography>
               )}
             </>
           
@@ -171,6 +187,14 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
       }      
       </>
     )}
+
+
+  <Dialog open={open} onClose={() => {setOpen(false)}} maxWidth={false} fullWidth>
+    <Grid item xs={12} md={12} sx={{ display: "flex" }}>
+      {showWhoComponent}
+    </Grid>
+  </Dialog>
+
   </>
 );
 }

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -12,93 +12,96 @@ import ErrorIcon from "@mui/icons-material/Error";
 
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
-const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {  
+const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu,
+  msg, showWhoComponent, showWhoList, condition, checkResultIcon, expandableData,
+  falseConditionMsg
+}) => {  
 
   const [open, setOpen] = useState(false);
   const [data, setData] = useState();
 
-  let msg;
-  let showWhoComponent;
-  let showWhoList;
+  // let msg;
+  // let showWhoComponent;
+  // let showWhoList;
 
-  // Aux tutores mientras pruebo
+  // // Aux tutores mientras pruebo
   let showWhoComponentTutors;
   let showWhoListTutors;
   let msgTutors;
 
-  let condition = true;
+  // let condition = true;
 
-  let checkResultIcon;
+  // let checkResultIcon;
 
-  let expandableData;
+  // let expandableData;
 
   switch (algorithm) {
     case "IncompleteTeams": {
 
-      if (inputInfo) {
+    //   if (inputInfo && condition!==undefined) {
 
-        msg = inputInfo.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
-        : inputInfo.length === 1 ? "Existe 1 estudiante que no está en respuestas al formulario de equipos en ninguna de sus variantes"
-        : `Existen ${inputInfo.length} estudiantes que no están en respuestas al formulario de equipos en ninguna de sus variantes`
+    //     msg = inputInfo.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
+    //     : inputInfo.length === 1 ? "Existe 1 estudiante que no está en respuestas al formulario de equipos en ninguna de sus variantes"
+    //     : `Existen ${inputInfo.length} estudiantes que no están en respuestas al formulario de equipos en ninguna de sus variantes`
   
-        showWhoList = inputInfo;
-        showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
+    //     showWhoList = inputInfo;
+    //     showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
 
-        expandableData = [{title: msg, detail: showWhoComponent}]
+    //     expandableData = [{title: msg, detail: showWhoComponent}]
   
-        // "condition" queda en true (ponerle un mejor nombre)
+    //     // "condition" queda en true (ponerle un mejor nombre)
 
-        // Ícono
-        checkResultIcon = inputInfo.length === 0
-        ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>
+    //     // Ícono
+    //     checkResultIcon = inputInfo.length === 0
+    //     ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>
         
-        if (!condition) {
-          checkResultIcon = <ErrorIcon color="error"/>
-        }
+    //     if (!condition) {
+    //       checkResultIcon = <ErrorIcon color="error"/>
+    //     }
 
-      }
+    //   }
 
       break;
     }
-    case "Dates": {      
+    case "Dates": {  
 
-      if (inputInfo) {
+      // if (inputInfo) {
         
-        condition = inputInfo.admin_slots;
+      //   condition = inputInfo.admin_slots;
         
-        msg =
-          inputInfo.teams?.length === 0 ? "Todos los equipos completaron su disponibilidad."
-          : inputInfo.teams?.length === 1 ? "Existe 1 equipo que no completó su disponibilidad"
-          : `Existen ${inputInfo.teams?.length} equipos que no completaron su disponibilidad`
+      //   msg =
+      //     inputInfo.teams?.length === 0 ? "Todos los equipos completaron su disponibilidad."
+      //     : inputInfo.teams?.length === 1 ? "Existe 1 equipo que no completó su disponibilidad"
+      //     : `Existen ${inputInfo.teams?.length} equipos que no completaron su disponibilidad`
         
-        showWhoList = inputInfo.teams;
-        showWhoComponent = <TeamsTable dataListToRender={showWhoList} />;
+      //   showWhoList = inputInfo.teams;
+      //   showWhoComponent = <TeamsTable dataListToRender={showWhoList} />;
 
 
-        // Ícono
-        checkResultIcon = inputInfo.length === 0
-        ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>
+      //   // Ícono
+      //   checkResultIcon = inputInfo.length === 0
+      //   ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>
         
-        if (!condition) {
-          checkResultIcon = checkResultIcon = <ErrorIcon color="error"/>
-        }
+      //   if (!condition) {
+      //     checkResultIcon = checkResultIcon = <ErrorIcon color="error"/>
+      //   }
 
-        //////////
-        // Tutores
-        showWhoListTutors = inputInfo.teachers;
-        showWhoComponentTutors = <TutorsTable dataListToRender={showWhoListTutors} />;      
-        msgTutors = 
-          inputInfo.teachers?.length === 0 ? "Todos/as los/as tutores/as completaron su disponibilidad."
-          : inputInfo.teachers?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad"
-          : `Existen ${inputInfo.teachers?.length} tutores/as que no completaron su disponibilidad`      
-      }
+      //   //////////
+      //   // Tutores
+      //   const showWhoListTutors = inputInfo.teachers;
+      //   const showWhoComponentTutors = <TutorsTable dataListToRender={showWhoListTutors} />;      
+      //   const msgTutors = 
+      //     inputInfo.teachers?.length === 0 ? "Todos/as los/as tutores/as completaron su disponibilidad."
+      //     : inputInfo.teachers?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad"
+      //     : `Existen ${inputInfo.teachers?.length} tutores/as que no completaron su disponibilidad`      
+      // }
       
 
 
-      expandableData = [{title: msg, detail: showWhoComponent},
-                        {title: msgTutors, detail: showWhoComponentTutors}
-      ]
-      if (!setSelectedMenu) return;
+      // expandableData = [{title: msg, detail: showWhoComponent},
+      //                   {title: msgTutors, detail: showWhoComponentTutors}
+      // ]
+      // if (!setSelectedMenu) return;
       
       break;
     }
@@ -107,6 +110,12 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
       msg = "Ocurrió un error inesperado al mostrar información";
     }
   }
+
+  // Nop, esto siempre da true -_-
+  // if (condition === undefined) {
+  //   return
+  // }
+  console.log("--- condition:", condition);
 
   return (
     <>
@@ -195,17 +204,7 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
           
           <Grid item xs={12} md={12} sx={{ display: "flex", gap: 0.5 }}>
             {checkResultIcon}
-            <Typography component={"span"}>
-              <strong>Primero se debe cargar las fechas disponibles desde la sección {' '}</strong>
-            </Typography>
-            <Link
-              component="span"
-              onClick={() => setSelectedMenu("Disponibilidad fechas de Presentación")}
-              underline="always"
-              sx={{ color: "blue", cursor: "pointer", ml: 0.5}}
-              >
-              Disponibilidad fechas de Presentación
-            </Link>.
+            {falseConditionMsg}
           </Grid>
           )
       }      

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Grid, Typography, Link } from "@mui/material";
 import StudentsTable from "../UI/Tables/ChildTables/StudentsTable";
 import TeamsTable from "../UI/Tables/ChildTables/GroupsTable";
+import TutorsTable from "../UI/Tables/ChildTables/TutorsTable";
 
 const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {  
   if (!inputInfo) return;  
@@ -9,6 +10,11 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
   let msg;
   let showWhoComponent;
   let showWhoList;
+
+  // Aux tutores mientras pruebo
+  let showWhoComponentTutors;
+  let showWhoListTutors;
+  let msgTutors;
   switch (algorithm) {
     case "IncompleteTeams": {
       msg = inputInfo.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
@@ -42,7 +48,28 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
         )
       
       showWhoList = inputInfo.teams;
-      showWhoComponent = <TeamsTable dataListToRender={showWhoList} />;      
+      showWhoComponent = <TeamsTable dataListToRender={showWhoList} />;
+      
+      // Tutores
+      showWhoListTutors = inputInfo.teachers;
+      showWhoComponentTutors = <TutorsTable dataListToRender={showWhoListTutors} />;      
+      msgTutors = inputInfo.admin_slots ? (
+        inputInfo.teachers?.length === 0 ? "Todos los tutores/as completaron su disponibilidad."
+        : inputInfo.teachers?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad:"
+        : `Existen ${inputInfo.teachers?.length} tutoras/es que no completaron su disponibilidad:`
+      ) : ( // cambiar esta estructura de ifs xq no quiero dar dos veces este msj de abajo, va ese chack primero
+        <>
+          Primero se debe cargar las fechas disponibles desde la sección {""}
+          <Link
+            component="span"
+            onClick={() => setSelectedMenu("Disponibilidad fechas de Presentación")}
+            underline="always"
+            sx={{ color: "blue", cursor: "pointer"}}
+            >
+            Disponibilidad fechas de Presentación
+          </Link>.
+        </>
+        )
       
       break;
     }
@@ -73,9 +100,27 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
         </Typography>
       </Grid>      
 
-      {showWhoList.length > 0 && (<Grid item xs={12} md={12} sx={{ display: "flex" }}>  
-        {showWhoComponent}
-      </Grid>)}
+      {showWhoList.length > 0 && (
+        <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
+          {showWhoComponent}
+        </Grid>)
+      }
+
+      {/* Tutores - fechas */}
+      {showWhoListTutors.length > 0 && (
+        <>
+        <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
+          <Typography variant="body1" sx={{ textAlign: "justify" }}>
+            {msgTutors}
+          </Typography>
+        </Grid>
+        <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
+          {showWhoComponentTutors}
+        </Grid>
+        </>
+        )
+      }
+
       </>
     )}
   </>

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -3,18 +3,35 @@ import { Grid, Typography, Box, CircularProgress,
          Dialog, Button, DialogTitle, DialogContent,
          Accordion, AccordionSummary, AccordionDetails } from "@mui/material";
 
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import ErrorIcon from "@mui/icons-material/Error";
+
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 const AlgorithmPreCheck = ({
   initialDescription,
-  condition, checkResultIcon, expandableData,
+  condition=true,
+  expandableData,
   falseConditionMsg
 }) => {  
 
   const [open, setOpen] = useState(false);
   const [data, setData] = useState();
 
-  // True si alguna de las listas muestra problemas, para saber si debo mostrar el botón de "Analizar"
+  const getIcon = (list) => {
+    if (list.length === 0) {
+        return <CheckCircleIcon color="success"/>
+    }
+    if (list.length > 0) {        
+        return <WarningAmberIcon color="warning"/>
+    }
+  }
+  
+  // Agregamos ícono a cada mensaje a mostrar
+  const dataWithIcons = expandableData?.map(elem => ({ ...elem, icon: getIcon(elem.infoList) }));
+  
+  // True si alguna de las listas muestra 'entidades problemáticas', para saber si debo mostrar el botón de "Analizar"
   const areThereProblems = expandableData?.some(element => element.infoList.length > 0);
 
   return (
@@ -34,7 +51,7 @@ const AlgorithmPreCheck = ({
         </Box>
       </Grid>
     )}
-    {expandableData && (
+    {dataWithIcons && (
       <>
       <Grid item xs={12} md={12} sx={{ display: "flex" }}>
         <Typography variant="body1" sx={{ textAlign: "justify" }}>
@@ -45,7 +62,7 @@ const AlgorithmPreCheck = ({
       {condition ? (
         <>
         {/* Muestro lista de cada msj (ej "Existen _n_ ... que no ...", o msj de Todo ok) con su ícono*/}
-          {expandableData?.map((okMsgOrProblematicEntity) => (
+          {dataWithIcons?.map((okMsgOrProblematicEntity) => (
             <Grid item xs={12} md={12} sx={{ display: "flex", gap: 0.5}}>  
               {okMsgOrProblematicEntity.icon}
               <Typography variant="body1" sx={{ textAlign: "justify" }}>
@@ -57,8 +74,8 @@ const AlgorithmPreCheck = ({
           {areThereProblems && condition && (          
             <Typography variant="body1" sx={{ textAlign: "justify" }}>
               <Button
-                variant="outlined"
-                onClick={() => {setData(expandableData); setOpen(true)}}
+                variant="outlined"                
+                onClick={() => {setData(dataWithIcons); setOpen(true)}}
               >
                 Analizar
               </Button>
@@ -68,7 +85,7 @@ const AlgorithmPreCheck = ({
       ) : (
         <Grid item xs={12} md={12} sx={{ display: "flex", gap: 0.5 }}>
           {/* Si esto es false, no aplica mostrarlos xq existe otro problema ("primero admin cargar fechas")*/}
-          {checkResultIcon}
+          <ErrorIcon color="error"/>
           {falseConditionMsg}
         </Grid>
       )

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -5,7 +5,7 @@ import TeamsTable from "../UI/Tables/ChildTables/GroupsTable";
 import TutorsTable from "../UI/Tables/ChildTables/TutorsTable";
 
 const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {  
-  if (!inputInfo) return;  
+  if (!inputInfo) return;
 
   let msg;
   let showWhoComponent;

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -1,13 +1,13 @@
 import React, {useState} from "react";
-import { Grid, Typography, Link, Box, CircularProgress,
+import { Grid, Typography, Box, CircularProgress,
          Dialog, Button, DialogTitle, DialogContent,
          Accordion, AccordionSummary, AccordionDetails, } from "@mui/material";
 
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 const AlgorithmPreCheck = ({
-  initialDescription, inputInfo, setSelectedMenu,
-  msg, showWhoComponent, showWhoList, condition, checkResultIcon, expandableData,
+  initialDescription,
+  condition, checkResultIcon, expandableData,
   falseConditionMsg
 }) => {  
 
@@ -21,7 +21,7 @@ const AlgorithmPreCheck = ({
         Verificación previa
       </Typography>
     </Grid>
-    {!inputInfo && (
+    {!expandableData && (
       <Grid item xs={12} md={12} sx={{ display: "flex" }}>
         <Box
           display="flex"
@@ -31,7 +31,7 @@ const AlgorithmPreCheck = ({
         </Box>
       </Grid>
     )}
-    {inputInfo && (
+    {expandableData && (
       <>
       <Grid item xs={12} md={12} sx={{ display: "flex" }}>
         <Typography variant="body1" sx={{ textAlign: "justify" }}>
@@ -45,7 +45,7 @@ const AlgorithmPreCheck = ({
           {expandableData?.map((okMsgOrProblematicEntity) => (
             <>
             <Grid item xs={12} md={12} sx={{ display: "flex", gap: 0.5}}>  
-              {checkResultIcon}
+              {okMsgOrProblematicEntity.icon}
               <Typography variant="body1" sx={{ textAlign: "justify" }}>
                 <strong>{okMsgOrProblematicEntity.title}</strong>
               </Typography>

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -98,7 +98,7 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
             <>
               <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
                 <Typography variant="body1" sx={{ textAlign: "justify" }}>
-                  {msg}
+                  <strong>{msg}</strong>
                 </Typography>
               </Grid>      
 
@@ -113,7 +113,7 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
               {/* Tutores - fechas */}
               <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
                 <Typography variant="body1" sx={{ textAlign: "justify" }}>
-                  {msgTutors}
+                  <strong>{msgTutors}</strong>
                 </Typography>
               </Grid>
               {showWhoListTutors?.length > 0 && (
@@ -126,12 +126,14 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
       ) : (
           
           <Grid item xs={12} md={12} sx={{ display: "flex" }}>
-            Primero se debe cargar las fechas disponibles desde la sección {""}
+            <Typography component={"span"}>
+              <strong>Primero se debe cargar las fechas disponibles desde la sección {' '}</strong>
+            </Typography>
             <Link
               component="span"
               onClick={() => setSelectedMenu("Disponibilidad fechas de Presentación")}
               underline="always"
-              sx={{ color: "blue", cursor: "pointer"}}
+              sx={{ color: "blue", cursor: "pointer", ml: 0.5}}
               >
               Disponibilidad fechas de Presentación
             </Link>.

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -1,7 +1,7 @@
 import React, {useState} from "react";
 import { Grid, Typography, Box, CircularProgress,
          Dialog, Button, DialogTitle, DialogContent,
-         Accordion, AccordionSummary, AccordionDetails, } from "@mui/material";
+         Accordion, AccordionSummary, AccordionDetails } from "@mui/material";
 
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
@@ -13,6 +13,9 @@ const AlgorithmPreCheck = ({
 
   const [open, setOpen] = useState(false);
   const [data, setData] = useState();
+
+  // True si alguna de las listas muestra problemas, para saber si debo mostrar el botón de "Analizar"
+  const areThereProblems = expandableData?.some(element => element.infoList.length > 0);
 
   return (
     <>
@@ -43,15 +46,15 @@ const AlgorithmPreCheck = ({
         <>
         {/* Muestro lista de cada msj (ej "Existen _n_ ... que no ...", o msj de Todo ok) con su ícono*/}
           {expandableData?.map((okMsgOrProblematicEntity) => (
-            <>
             <Grid item xs={12} md={12} sx={{ display: "flex", gap: 0.5}}>  
               {okMsgOrProblematicEntity.icon}
               <Typography variant="body1" sx={{ textAlign: "justify" }}>
                 <strong>{okMsgOrProblematicEntity.title}</strong>
               </Typography>
             </Grid>
+          ))}
           {/* Si hay gente que falte al input, y aplique mostrar, muestro botón para ver quiénes son en modal */}
-          {okMsgOrProblematicEntity.infoList.length > 0 && condition && (
+          {areThereProblems && condition && (          
             <Typography variant="body1" sx={{ textAlign: "justify" }}>
               <Button
                 variant="outlined"
@@ -61,8 +64,6 @@ const AlgorithmPreCheck = ({
               </Button>
             </Typography>
           )}
-           </>
-          ))}
           </>
       ) : (
         <Grid item xs={12} md={12} sx={{ display: "flex", gap: 0.5 }}>

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -6,7 +6,7 @@ import { Grid, Typography, Link, Box, CircularProgress,
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 const AlgorithmPreCheck = ({
-  initialDescription, inputInfo, algorithm, setSelectedMenu,
+  initialDescription, inputInfo, setSelectedMenu,
   msg, showWhoComponent, showWhoList, condition, checkResultIcon, expandableData,
   falseConditionMsg
 }) => {  
@@ -50,18 +50,13 @@ const AlgorithmPreCheck = ({
               <Grid item xs={12} md={12} sx={{ display: "flex", gap: 0.5}}>  
                 {checkResultIcon}
                 <Typography variant="body1" sx={{ textAlign: "justify" }}>
-                  <strong>{msg}</strong>
+                  <strong>{expandableData[0].title}</strong>
                 </Typography>
               </Grid>
 
-              {/* Éste no va */}
-              {false && showWhoList?.length > 0 && (
-                <Grid item xs={12} md={12} sx={{ display: "flex" }}>
-                  {showWhoComponent}
-                </Grid>
-              )}
               {/* Va éste. y hay que reutilizar cosas acá, el "inputInfo" es lo variable */}
-              {inputInfo.length > 0 && condition && (
+              {/*inputInfo.length > 0 && condition && (*/}
+              {expandableData[0].infoList.length > 0 && condition && (
                 <Typography variant="body1" sx={{ textAlign: "justify" }}>
                   <Button
                     variant="outlined"
@@ -80,12 +75,7 @@ const AlgorithmPreCheck = ({
                 <Typography variant="body1" sx={{ textAlign: "justify" }}>
                   <strong>{msgTutors}</strong>
                 </Typography>
-              </Grid>
-              {false && showWhoListTutors?.length > 0 && (
-                <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
-                  {showWhoComponentTutors}
-                </Grid>
-              )}
+              </Grid>              
 
                {/* Va éste. veamosssssssss _ en realidad no del todo pero probando __ y hay que reutilizar cosas acá, el "inputInfo" es lo variable */}
                {inputInfo.teachers?.length > 0 && condition && (

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -36,6 +36,10 @@ export const Title = ({withSpinner=false}) => {
   )
 }
 
+// Componente genérico, recibe los datos ya procesados de SpecificAlgorithmsPreCheck.js
+// les agrega íconos y se encarga del renderizado. Muestra a admin que hay entidades con problemas
+// (ej estudiantes / equipos / tutores que faltan al input de los algoritmos) y en un modal
+// muestra quiénes son.
 export const AlgorithmPreCheck = ({
   initialDescription,
   condition=true,

--- a/src/components/Algorithms/AlgorithmPreCheck.js
+++ b/src/components/Algorithms/AlgorithmPreCheck.js
@@ -4,6 +4,10 @@ import StudentsTable from "../UI/Tables/ChildTables/StudentsTable";
 import TeamsTable from "../UI/Tables/ChildTables/GroupsTable";
 import TutorsTable from "../UI/Tables/ChildTables/TutorsTable";
 
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import ErrorIcon from "@mui/icons-material/Error";
+
 const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {  
   //if (!inputInfo) return;
 
@@ -18,6 +22,8 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
 
   let condition = true;
 
+  let checkResultIcon;
+
   switch (algorithm) {
     case "IncompleteTeams": {
 
@@ -31,6 +37,15 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
         showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
   
         // "condition" queda en true (ponerle un mejor nombre)
+
+        // Ícono
+        checkResultIcon = inputInfo.length === 0
+        ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>
+        
+        if (!condition) {
+          checkResultIcon = <ErrorIcon color="error"/>
+        }
+
       }
 
       break;
@@ -48,7 +63,19 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
         
         showWhoList = inputInfo.teams;
         showWhoComponent = <TeamsTable dataListToRender={showWhoList} />;
-  
+
+        checkResultIcon = inputInfo.teams?.length === 0
+        ? <CheckCircleIcon /> : <WarningAmberIcon />
+
+        // Ícono
+        checkResultIcon = inputInfo.length === 0
+        ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>
+        
+        if (!condition) {
+          checkResultIcon = checkResultIcon = <ErrorIcon color="error"/>
+        }
+
+        //////////
         // Tutores
         showWhoListTutors = inputInfo.teachers;
         showWhoComponentTutors = <TutorsTable dataListToRender={showWhoListTutors} />;      
@@ -96,7 +123,8 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
       {condition ? (
         <>          
             <>
-              <Grid item xs={12} md={12} sx={{ display: "flex" }}>  
+              <Grid item xs={12} md={12} sx={{ display: "flex", gap: 0.5}}>  
+                {checkResultIcon}
                 <Typography variant="body1" sx={{ textAlign: "justify" }}>
                   <strong>{msg}</strong>
                 </Typography>
@@ -125,7 +153,8 @@ const AlgorithmPreCheck = ({initialDescription, inputInfo, algorithm, setSelecte
         </>
       ) : (
           
-          <Grid item xs={12} md={12} sx={{ display: "flex" }}>
+          <Grid item xs={12} md={12} sx={{ display: "flex", gap: 0.5 }}>
+            {checkResultIcon}
             <Typography component={"span"}>
               <strong>Primero se debe cargar las fechas disponibles desde la sección {' '}</strong>
             </Typography>

--- a/src/components/Algorithms/Dates.js
+++ b/src/components/Algorithms/Dates.js
@@ -569,7 +569,7 @@ const Dates = ({setSelectedMenu}) => {
         {/* Descripción */}
         <Description />
         {/* Verificación Previa */}
-        <DatesPreCheck inputInfo={inputInfo} algorithm={"Dates"} setSelectedMenu={setSelectedMenu}/>
+        <DatesPreCheck inputInfo={inputInfo} setSelectedMenu={setSelectedMenu}/>
 
         {/* Botones Correr */}
         <ButtonSection

--- a/src/components/Algorithms/Dates.js
+++ b/src/components/Algorithms/Dates.js
@@ -116,7 +116,6 @@ const Dates = ({setSelectedMenu}) => {
   const dispatch = useDispatch();
 
   // Fechas
-
   useEffect(() => {
     
     // Análsis del input del algoritmo, previo a ejecutarlo

--- a/src/components/Algorithms/Dates.js
+++ b/src/components/Algorithms/Dates.js
@@ -569,7 +569,7 @@ const Dates = ({setSelectedMenu}) => {
         {/* Descripción */}
         <Description />
         {/* Verificación Previa */}
-        <AlgorithmPreCheck inputInfo={inputInfo} algorithm={"Dates"} setSelectedMenu={setSelectedMenu}/>        
+        {/*<AlgorithmPreCheck inputInfo={inputInfo} algorithm={"Dates"} setSelectedMenu={setSelectedMenu}/>*/}
 
         {/* Botones Correr */}
         <ButtonSection

--- a/src/components/Algorithms/Dates.js
+++ b/src/components/Algorithms/Dates.js
@@ -36,7 +36,6 @@ import updatePeriod from "../../api/updatePeriod";
 import ResultsDialog from "./Dates/ResultsDialog";
 
 import { getInputAnalysis } from "../../api/handleAlgorithmAnalysis";
-import AlgorithmPreCheck from "./AlgorithmPreCheck";
 import { DatesPreCheck } from "./SpecificAlgorithmsPreCheck";
 
 const evaluatorColors = [
@@ -570,7 +569,6 @@ const Dates = ({setSelectedMenu}) => {
         {/* Descripción */}
         <Description />
         {/* Verificación Previa */}
-        {/*<AlgorithmPreCheck inputInfo={inputInfo} algorithm={"Dates"} setSelectedMenu={setSelectedMenu}/>*/}
         <DatesPreCheck inputInfo={inputInfo} algorithm={"Dates"} setSelectedMenu={setSelectedMenu}/>
 
         {/* Botones Correr */}

--- a/src/components/Algorithms/Dates.js
+++ b/src/components/Algorithms/Dates.js
@@ -37,6 +37,7 @@ import ResultsDialog from "./Dates/ResultsDialog";
 
 import { getInputAnalysis } from "../../api/handleAlgorithmAnalysis";
 import AlgorithmPreCheck from "./AlgorithmPreCheck";
+import { DatesPreCheck } from "./SpecificAlgorithmsPreCheck";
 
 const evaluatorColors = [
   "#87CEFA", // Light Blue
@@ -570,6 +571,7 @@ const Dates = ({setSelectedMenu}) => {
         <Description />
         {/* Verificación Previa */}
         {/*<AlgorithmPreCheck inputInfo={inputInfo} algorithm={"Dates"} setSelectedMenu={setSelectedMenu}/>*/}
+        <DatesPreCheck inputInfo={inputInfo} algorithm={"Dates"} setSelectedMenu={setSelectedMenu}/>
 
         {/* Botones Correr */}
         <ButtonSection

--- a/src/components/Algorithms/GroupDataTable.js
+++ b/src/components/Algorithms/GroupDataTable.js
@@ -37,7 +37,7 @@ const TeamDataTable = ({
   items,
   title,
   enableEdit = true,
-  //enableDelete = true, // No existe endpoint delete para teams actualmente
+  enableDelete = true, // No existe endpoint delete para teams actualmente
   enableAdd = true,
   enableFilterButtons = true,
 }) => {

--- a/src/components/Algorithms/IncompleteGroups.js
+++ b/src/components/Algorithms/IncompleteGroups.js
@@ -27,7 +27,6 @@ import { setGroups } from "../../redux/slices/groupsSlice";
 import { togglePeriodSetting } from "../../redux/slices/periodSlice";
 import updatePeriod from "../../api/updatePeriod";
 import { useNavigate } from "react-router-dom";
-//import AlgorithmPreCheck from "./AlgorithmPreCheck";
 import { IncompleteTeamsPreCheck } from "./SpecificAlgorithmsPreCheck";
 
 const IncompleteGroups = () => {
@@ -152,7 +151,6 @@ const IncompleteGroups = () => {
         </Grid>
 
         {/* Verificación Previa */}
-        {/*<AlgorithmPreCheck initialDescription={preCheckMsg} inputInfo={inputInfo} algorithm={"IncompleteTeams"}/>*/}
         <IncompleteTeamsPreCheck initialDescription={preCheckMsg} inputInfo={inputInfo} algorithm={"IncompleteTeams"}/>
         
         {/* Botones Correr, Editar */}

--- a/src/components/Algorithms/IncompleteGroups.js
+++ b/src/components/Algorithms/IncompleteGroups.js
@@ -158,7 +158,7 @@ const IncompleteGroups = () => {
         <Grid
           item
           xs={12}
-          md={2}
+          md={1}
           sx={{ display: "flex", justifyContent: "right" }}
         >
           <Button

--- a/src/components/Algorithms/IncompleteGroups.js
+++ b/src/components/Algorithms/IncompleteGroups.js
@@ -53,13 +53,14 @@ const IncompleteGroups = () => {
     setOpenConfirmDialog(true); // Muestra el diálogo de confirmación al presionar el botón "Correr"
   };
   
-  // Análsis del input del algoritmo, previo a ejecutarlo
-  const endpoint = "/incomplete_teams_algorithm_input_info"
   // (Esta sintaxis del '+' es solo para hacer un salto de línea en el ide, no afecta al renderizado)
   const preCheckMsg = `Este algoritmo utiliza las respuestas al formulario de equipos`+
-        ` (Preferencias / Ya tengo tema y tutor) como input, para completar los equipos en base a sus preferencias.`
+  ` (Preferencias / Ya tengo tema y tutor) como input, para completar los equipos en base a sus preferencias.`
   useEffect(() => {
+    
+    // Análsis del input del algoritmo, previo a ejecutarlo
     const getInputInfo = async () => {
+      const endpoint = "/incomplete_teams_algorithm_input_info"
       try {
         const data = await getInputAnalysis(endpoint, period.id, user);        
         setInputInfo(data);

--- a/src/components/Algorithms/IncompleteGroups.js
+++ b/src/components/Algorithms/IncompleteGroups.js
@@ -27,7 +27,8 @@ import { setGroups } from "../../redux/slices/groupsSlice";
 import { togglePeriodSetting } from "../../redux/slices/periodSlice";
 import updatePeriod from "../../api/updatePeriod";
 import { useNavigate } from "react-router-dom";
-import AlgorithmPreCheck from "./AlgorithmPreCheck";
+//import AlgorithmPreCheck from "./AlgorithmPreCheck";
+import { IncompleteTeamsPreCheck } from "./SpecificAlgorithmsPreCheck";
 
 const IncompleteGroups = () => {
   const period = useSelector((state) => state.period);
@@ -151,7 +152,8 @@ const IncompleteGroups = () => {
         </Grid>
 
         {/* Verificación Previa */}
-        <AlgorithmPreCheck initialDescription={preCheckMsg} inputInfo={inputInfo} algorithm={"IncompleteTeams"}/>        
+        {/*<AlgorithmPreCheck initialDescription={preCheckMsg} inputInfo={inputInfo} algorithm={"IncompleteTeams"}/>*/}
+        <IncompleteTeamsPreCheck initialDescription={preCheckMsg} inputInfo={inputInfo} algorithm={"IncompleteTeams"}/>
         
         {/* Botones Correr, Editar */}
         <Grid

--- a/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
+++ b/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
@@ -10,6 +10,11 @@ import ErrorIcon from "@mui/icons-material/Error";
 
 import AlgorithmPreCheck from "./AlgorithmPreCheck";
 
+// export const ExpandableData = ({}) => {
+
+
+// }
+
 export const IncompleteTeamsPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {
   if (inputInfo) {
     // A ESTE LO TRAIGO DE AFUERA:
@@ -24,28 +29,24 @@ export const IncompleteTeamsPreCheck = ({initialDescription, inputInfo, algorith
     const showWhoList = inputInfo;
     const showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
 
-    // los dos primeros campos se usan para el modal, pero el tercero se usa para ver su len y si debería renderizarse
-    const expandableData = [{title: studentsMsg, detail: showWhoComponent, infoList: showWhoList}]
-    //const data = [{msg: studentsMsg, infoList: showWhoList}]
-
     const condition = true //(ponerle un mejor nombre)
-
+    
     // Ícono
     let checkResultIcon = inputInfo.length === 0
     ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>    
     if (!condition) {
-      checkResultIcon = <ErrorIcon color="error"/>
+        checkResultIcon = <ErrorIcon color="error"/>
     }
-
-    console.log("--- condition a pasar:", condition);
-
+    
+    // los dos primeros campos se usan para el modal, pero el tercero se usa para ver su len y si debería renderizarse
+    const expandableData = [{title: studentsMsg, detail: showWhoComponent, infoList: showWhoList, icon: checkResultIcon}]
     
     // AUX: esto debe ir acá xq afuera del if no existen las variables que le estoy pasando
     // Aux: Equipos incompletos no lleva set :)
-    return <AlgorithmPreCheck initialDescription={initialDescription} inputInfo={inputInfo} algorithm={"IncompleteTeams"}
-          msg={studentsMsg} showWhoList={inputInfo} showWhoComponent={showWhoComponent}
+    return <AlgorithmPreCheck initialDescription={initialDescription}
           expandableData={expandableData} condition={true} checkResultIcon={checkResultIcon}
-          falseConditionMsg={"Dev error"} />
+          //falseConditionMsg={"Dev error"}
+          />
   } else {
     // AUX )cont): pero poner ese return en el if acá arriba, hace que acá solo haga return en vez de mostrar el
     // spinner. Debería mostrar el spinner acá.
@@ -71,25 +72,29 @@ export const DatesPreCheck = ({initialDescription, inputInfo, algorithm, setSele
         let checkResultIcon = inputInfo.length === 0
         ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>        
         if (!condition) {
-          checkResultIcon = checkResultIcon = <ErrorIcon color="error"/>
+          checkResultIcon = <ErrorIcon color="error"/>
         }
 
         //////////
         // Tutores
-        const showWhoListTutors = inputInfo.teachers;
-        const showWhoComponentTutors = <TutorsTable dataListToRender={showWhoListTutors} />;      
+        const showWhoTutorsList = inputInfo.teachers;
+        const showWhoTutorsComponent = <TutorsTable dataListToRender={showWhoTutorsList} />;      
         const tutorsMsg = 
           inputInfo.teachers?.length === 0 ? "Todos/as los/as tutores/as completaron su disponibilidad."
           : inputInfo.teachers?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad"
           : `Existen ${inputInfo.teachers?.length} tutores/as que no completaron su disponibilidad`      
+        // Ícono
+        let tutorsIcon = inputInfo.length === 0
+        ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>        
+        if (!condition) {
+            tutorsIcon = <ErrorIcon color="error"/>
+        }
+
+
         
         // los dos primeros campos se usan para el modal, pero el tercero se usa para ver su len y si debería renderizarse
-        const expandableData = [{title: teamsMsg, detail: showWhoComponent, infoList: showWhoList},
-                            {title: tutorsMsg, detail: showWhoComponentTutors, infoList: showWhoListTutors}]
-        // const data = [
-        //     {msg: teamsMsg, infoList: showWhoList},
-        //     {msg: tutorsMsg, infoList: showWhoListTutors}
-        // ]
+        const expandableData = [{title: teamsMsg, detail: showWhoComponent, infoList: showWhoList, icon: checkResultIcon},
+                            {title: tutorsMsg, detail: showWhoTutorsComponent, infoList: showWhoTutorsList, icon: tutorsIcon}]
         if (!setSelectedMenu) return;
 
 
@@ -113,8 +118,7 @@ export const DatesPreCheck = ({initialDescription, inputInfo, algorithm, setSele
         );
 
         // AUX hay que ponerle un map para pasarle más de un msg... o algo así, ver.
-        return <AlgorithmPreCheck inputInfo={inputInfo} algorithm={"IncompleteTeams"}
-          msg={teamsMsg} showWhoList={inputInfo?.teams} showWhoComponent={showWhoComponent}
+        return <AlgorithmPreCheck
           expandableData={expandableData} condition={condition} checkResultIcon={checkResultIcon}
           falseConditionMsg={falseConditionMsg} />
     }

--- a/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
+++ b/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
@@ -56,17 +56,69 @@ export const IncompleteTeamsPreCheck = ({initialDescription, inputInfo, algorith
 }
 
 export const DatesPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {
-  // Hay que pasarle esto.
-  // const falseConditionMsg = (<Typography component={"span"}>
-  //             <strong>Primero se debe cargar las fechas disponibles desde la sección {' '}</strong>
-  //           </Typography>
-  //           <Link
-  //             component="span"
-  //             onClick={() => setSelectedMenu("Disponibilidad fechas de Presentación")}
-  //             underline="always"
-  //             sx={{ color: "blue", cursor: "pointer", ml: 0.5}}
-  //             >
-  //             Disponibilidad fechas de Presentación
-  //           </Link>.)
+
+    if (inputInfo) {
+        
+        const condition = inputInfo.admin_slots;
+        
+        const msg =
+          inputInfo.teams?.length === 0 ? "Todos los equipos completaron su disponibilidad."
+          : inputInfo.teams?.length === 1 ? "Existe 1 equipo que no completó su disponibilidad"
+          : `Existen ${inputInfo.teams?.length} equipos que no completaron su disponibilidad`
+        
+        const showWhoList = inputInfo.teams;
+        const showWhoComponent = <TeamsTable dataListToRender={showWhoList} />;
+
+        // Ícono
+        let checkResultIcon = inputInfo.length === 0
+        ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>        
+        if (!condition) {
+          checkResultIcon = checkResultIcon = <ErrorIcon color="error"/>
+        }
+
+        //////////
+        // Tutores
+        const showWhoListTutors = inputInfo.teachers;
+        const showWhoComponentTutors = <TutorsTable dataListToRender={showWhoListTutors} />;      
+        const msgTutors = 
+          inputInfo.teachers?.length === 0 ? "Todos/as los/as tutores/as completaron su disponibilidad."
+          : inputInfo.teachers?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad"
+          : `Existen ${inputInfo.teachers?.length} tutores/as que no completaron su disponibilidad`      
+        
+        
+        const expandableData = [{title: msg, detail: showWhoComponent},
+                            {title: msgTutors, detail: showWhoComponentTutors}
+        ]
+        if (!setSelectedMenu) return;
+
+
+
+
+        /////
+        const falseConditionMsg = (
+            <>
+                <Typography component={"span"}>
+                    <strong>Primero se debe cargar las fechas disponibles desde la sección {' '}</strong>
+                </Typography>
+                <Link
+                    component="span"
+                    onClick={() => setSelectedMenu("Disponibilidad fechas de Presentación")}
+                    underline="always"
+                    sx={{ color: "blue", cursor: "pointer", ml: 0.5}}
+                    >
+                    Disponibilidad fechas de Presentación
+                </Link>.
+            </>
+        );
+
+        // AUX hay que ponerle un map para pasarle más de un msg... o algo así, ver.
+        return <AlgorithmPreCheck inputInfo={inputInfo} algorithm={"IncompleteTeams"}
+          msg={msg} showWhoList={inputInfo?.teams} showWhoComponent={showWhoComponent}
+          expandableData={expandableData} condition={condition} checkResultIcon={checkResultIcon}
+          falseConditionMsg={falseConditionMsg} />
+    }
+    
+
+   
 
 }

--- a/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
+++ b/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
@@ -1,10 +1,10 @@
 import React from "react";
-import { Typography, Link, } from "@mui/material";
+import { Typography, Link } from "@mui/material";
 import StudentsTable from "../UI/Tables/ChildTables/StudentsTable";
 import TeamsTable from "../UI/Tables/ChildTables/GroupsTable";
 import TutorsTable from "../UI/Tables/ChildTables/TutorsTable";
 
-import AlgorithmPreCheck from "./AlgorithmPreCheck";
+import { AlgorithmPreCheck, Title } from "./AlgorithmPreCheck";
 
 export const IncompleteTeamsPreCheck = ({initialDescription, inputInfo}) => {
   if (inputInfo) {    
@@ -24,15 +24,13 @@ export const IncompleteTeamsPreCheck = ({initialDescription, inputInfo}) => {
       condition={true}
     />
   } else {
-    // AUX )cont): pero poner ese return en el if acá arriba, hace que acá solo haga return en vez de mostrar el
-    // spinner. Debería mostrar el spinner acá.
-    return;
+    return <Title withSpinner={true} />
   }
 }
 
 export const DatesPreCheck = ({inputInfo, setSelectedMenu}) => {
 
-    if (inputInfo) {
+    if (inputInfo && setSelectedMenu) {
 
         const externalCondition = inputInfo.admin_slots;
         
@@ -56,7 +54,6 @@ export const DatesPreCheck = ({inputInfo, setSelectedMenu}) => {
         // Los dos primeros campos se usan para el modal, el tercero se usa para ver su len y si debería renderizarse el botón
         const expandableData = [{title: teamsMsg, detail: showWhoTeamsComponent, infoList: showWhoTeamList},
                             {title: tutorsMsg, detail: showWhoTutorsComponent, infoList: showWhoTutorList}]
-        if (!setSelectedMenu) return;
 
         ///// Mensaje a mostrar si admin no cargó las fechas
         const falseConditionMsg = (
@@ -79,6 +76,8 @@ export const DatesPreCheck = ({inputInfo, setSelectedMenu}) => {
           condition={externalCondition}
           falseConditionMsg={falseConditionMsg}
         />
+    } else {
+        return <Title withSpinner={true} />
     }
     
 }

--- a/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
+++ b/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
@@ -1,7 +1,5 @@
-import React, {useState} from "react";
-import { Grid, Typography, Link, Box, CircularProgress,
-         Dialog, Button, DialogTitle, DialogContent,
-         Accordion, AccordionSummary, AccordionDetails, } from "@mui/material";
+import React from "react";
+import { Typography, Link, } from "@mui/material";
 import StudentsTable from "../UI/Tables/ChildTables/StudentsTable";
 import TeamsTable from "../UI/Tables/ChildTables/GroupsTable";
 import TutorsTable from "../UI/Tables/ChildTables/TutorsTable";
@@ -12,8 +10,6 @@ import ErrorIcon from "@mui/icons-material/Error";
 
 import AlgorithmPreCheck from "./AlgorithmPreCheck";
 
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-
 export const IncompleteTeamsPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {
   if (inputInfo) {
     // A ESTE LO TRAIGO DE AFUERA:
@@ -21,31 +17,33 @@ export const IncompleteTeamsPreCheck = ({initialDescription, inputInfo, algorith
     //     ` (Preferencias / Ya tengo tema y tutor) como input, para completar los equipos en base a sus preferencias.`
     // ^ SE LLAMA INITIAL DESCRIPTION ACÁ, igual se puede traer para adentro dsp
 
-    const msg = inputInfo.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
+    const studentsMsg = inputInfo.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
     : inputInfo.length === 1 ? "Existe 1 estudiante que no está en respuestas al formulario de equipos en ninguna de sus variantes"
     : `Existen ${inputInfo.length} estudiantes que no están en respuestas al formulario de equipos en ninguna de sus variantes`
 
     const showWhoList = inputInfo;
     const showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
 
-    const expandableData = [{title: msg, detail: showWhoComponent}]
+    // los dos primeros campos se usan para el modal, pero el tercero se usa para ver su len y si debería renderizarse
+    const expandableData = [{title: studentsMsg, detail: showWhoComponent, infoList: showWhoList}]
+    //const data = [{msg: studentsMsg, infoList: showWhoList}]
 
     const condition = true //(ponerle un mejor nombre)
 
     // Ícono
     let checkResultIcon = inputInfo.length === 0
-    ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>
-    
+    ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>    
     if (!condition) {
       checkResultIcon = <ErrorIcon color="error"/>
     }
 
     console.log("--- condition a pasar:", condition);
+
     
     // AUX: esto debe ir acá xq afuera del if no existen las variables que le estoy pasando
     // Aux: Equipos incompletos no lleva set :)
     return <AlgorithmPreCheck initialDescription={initialDescription} inputInfo={inputInfo} algorithm={"IncompleteTeams"}
-          msg={msg} showWhoList={inputInfo} showWhoComponent={showWhoComponent}
+          msg={studentsMsg} showWhoList={inputInfo} showWhoComponent={showWhoComponent}
           expandableData={expandableData} condition={true} checkResultIcon={checkResultIcon}
           falseConditionMsg={"Dev error"} />
   } else {
@@ -61,7 +59,7 @@ export const DatesPreCheck = ({initialDescription, inputInfo, algorithm, setSele
         
         const condition = inputInfo.admin_slots;
         
-        const msg =
+        const teamsMsg =
           inputInfo.teams?.length === 0 ? "Todos los equipos completaron su disponibilidad."
           : inputInfo.teams?.length === 1 ? "Existe 1 equipo que no completó su disponibilidad"
           : `Existen ${inputInfo.teams?.length} equipos que no completaron su disponibilidad`
@@ -80,15 +78,18 @@ export const DatesPreCheck = ({initialDescription, inputInfo, algorithm, setSele
         // Tutores
         const showWhoListTutors = inputInfo.teachers;
         const showWhoComponentTutors = <TutorsTable dataListToRender={showWhoListTutors} />;      
-        const msgTutors = 
+        const tutorsMsg = 
           inputInfo.teachers?.length === 0 ? "Todos/as los/as tutores/as completaron su disponibilidad."
           : inputInfo.teachers?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad"
           : `Existen ${inputInfo.teachers?.length} tutores/as que no completaron su disponibilidad`      
         
-        
-        const expandableData = [{title: msg, detail: showWhoComponent},
-                            {title: msgTutors, detail: showWhoComponentTutors}
-        ]
+        // los dos primeros campos se usan para el modal, pero el tercero se usa para ver su len y si debería renderizarse
+        const expandableData = [{title: teamsMsg, detail: showWhoComponent, infoList: showWhoList},
+                            {title: tutorsMsg, detail: showWhoComponentTutors, infoList: showWhoListTutors}]
+        // const data = [
+        //     {msg: teamsMsg, infoList: showWhoList},
+        //     {msg: tutorsMsg, infoList: showWhoListTutors}
+        // ]
         if (!setSelectedMenu) return;
 
 
@@ -113,7 +114,7 @@ export const DatesPreCheck = ({initialDescription, inputInfo, algorithm, setSele
 
         // AUX hay que ponerle un map para pasarle más de un msg... o algo así, ver.
         return <AlgorithmPreCheck inputInfo={inputInfo} algorithm={"IncompleteTeams"}
-          msg={msg} showWhoList={inputInfo?.teams} showWhoComponent={showWhoComponent}
+          msg={teamsMsg} showWhoList={inputInfo?.teams} showWhoComponent={showWhoComponent}
           expandableData={expandableData} condition={condition} checkResultIcon={checkResultIcon}
           falseConditionMsg={falseConditionMsg} />
     }

--- a/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
+++ b/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
@@ -79,5 +79,4 @@ export const DatesPreCheck = ({inputInfo, setSelectedMenu}) => {
     } else {
         return <Title withSpinner={true} />
     }
-    
 }

--- a/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
+++ b/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
@@ -4,30 +4,7 @@ import StudentsTable from "../UI/Tables/ChildTables/StudentsTable";
 import TeamsTable from "../UI/Tables/ChildTables/GroupsTable";
 import TutorsTable from "../UI/Tables/ChildTables/TutorsTable";
 
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import WarningAmberIcon from '@mui/icons-material/WarningAmber';
-import ErrorIcon from "@mui/icons-material/Error";
-
 import AlgorithmPreCheck from "./AlgorithmPreCheck";
-
-// export const ExpandableData = ({}) => {
-
-
-// }
-
-// getter auxiliar
-const getIcon = (list, externalCondition) => {
-
-    if (!externalCondition) {
-        return <ErrorIcon color="error"/>
-    }
-    if (list.length === 0) {
-        return <CheckCircleIcon color="success"/>
-    }
-    if (list.length > 0) {
-        return <WarningAmberIcon color="warning"/>
-    }
-}
 
 export const IncompleteTeamsPreCheck = ({initialDescription, inputInfo}) => {
   if (inputInfo) {    
@@ -37,18 +14,14 @@ export const IncompleteTeamsPreCheck = ({initialDescription, inputInfo}) => {
     const studentsMsg = showWhoList.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
     : showWhoList.length === 1 ? "Existe 1 estudiante que no está en respuestas al formulario de equipos en ninguna de sus variantes"
     : `Existen ${showWhoList.length} estudiantes que no están en respuestas al formulario de equipos en ninguna de sus variantes`
-
-    const externalCondition = true //    
-    const studentsIcon = getIcon(showWhoList, externalCondition);    
     
     // Los dos primeros campos se usan para el modal, el tercero se usa para ver su len y si debería renderizarse el botón
-    const expandableData = [{title: studentsMsg, detail: showWhoComponent, infoList: showWhoList, icon: studentsIcon}]
+    const expandableData = [{title: studentsMsg, detail: showWhoComponent, infoList: showWhoList}]
     
     return <AlgorithmPreCheck
       initialDescription={initialDescription}
       expandableData={expandableData}
       condition={true}
-      checkResultIcon={studentsIcon}
     />
   } else {
     // AUX )cont): pero poner ese return en el if acá arriba, hace que acá solo haga return en vez de mostrar el
@@ -70,8 +43,7 @@ export const DatesPreCheck = ({inputInfo, setSelectedMenu}) => {
             showWhoTeamList?.length === 0 ? "Todos los equipos completaron su disponibilidad."
           : showWhoTeamList?.length === 1 ? "Existe 1 equipo que no completó su disponibilidad"
           : `Existen ${showWhoTeamList?.length} equipos que no completaron su disponibilidad`
-        const teamsIcon = getIcon(showWhoTeamList, externalCondition);        
-        
+                
         ///// Tutores
         const showWhoTutorList = inputInfo.teachers;
         const showWhoTutorsComponent = <TutorsTable dataListToRender={showWhoTutorList} />;      
@@ -79,12 +51,11 @@ export const DatesPreCheck = ({inputInfo, setSelectedMenu}) => {
             showWhoTutorList?.length === 0 ? "Todos/as los/as tutores/as completaron su disponibilidad."
           : showWhoTutorList?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad"
           : `Existen ${showWhoTutorList?.length} tutores/as que no completaron su disponibilidad`              
-        const tutorsIcon = getIcon(showWhoTutorList, externalCondition);
         
         ///// Data
         // Los dos primeros campos se usan para el modal, el tercero se usa para ver su len y si debería renderizarse el botón
-        const expandableData = [{title: teamsMsg, detail: showWhoTeamsComponent, infoList: showWhoTeamList, icon: teamsIcon},
-                            {title: tutorsMsg, detail: showWhoTutorsComponent, infoList: showWhoTutorList, icon: tutorsIcon}]
+        const expandableData = [{title: teamsMsg, detail: showWhoTeamsComponent, infoList: showWhoTeamList},
+                            {title: tutorsMsg, detail: showWhoTutorsComponent, infoList: showWhoTutorList}]
         if (!setSelectedMenu) return;
 
         ///// Mensaje a mostrar si admin no cargó las fechas
@@ -106,7 +77,6 @@ export const DatesPreCheck = ({inputInfo, setSelectedMenu}) => {
         return <AlgorithmPreCheck
           expandableData={expandableData}
           condition={externalCondition}
-          checkResultIcon={teamsIcon}
           falseConditionMsg={falseConditionMsg}
         />
     }

--- a/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
+++ b/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
@@ -1,0 +1,72 @@
+import React, {useState} from "react";
+import { Grid, Typography, Link, Box, CircularProgress,
+         Dialog, Button, DialogTitle, DialogContent,
+         Accordion, AccordionSummary, AccordionDetails, } from "@mui/material";
+import StudentsTable from "../UI/Tables/ChildTables/StudentsTable";
+import TeamsTable from "../UI/Tables/ChildTables/GroupsTable";
+import TutorsTable from "../UI/Tables/ChildTables/TutorsTable";
+
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import ErrorIcon from "@mui/icons-material/Error";
+
+import AlgorithmPreCheck from "./AlgorithmPreCheck";
+
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+
+export const IncompleteTeamsPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {
+  if (inputInfo) {
+    // A ESTE LO TRAIGO DE AFUERA:
+    // const preCheckMsg = `Este algoritmo utiliza las respuestas al formulario de equipos`+    
+    //     ` (Preferencias / Ya tengo tema y tutor) como input, para completar los equipos en base a sus preferencias.`
+    // ^ SE LLAMA INITIAL DESCRIPTION ACÁ, igual se puede traer para adentro dsp
+
+    const msg = inputInfo.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
+    : inputInfo.length === 1 ? "Existe 1 estudiante que no está en respuestas al formulario de equipos en ninguna de sus variantes"
+    : `Existen ${inputInfo.length} estudiantes que no están en respuestas al formulario de equipos en ninguna de sus variantes`
+
+    const showWhoList = inputInfo;
+    const showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
+
+    const expandableData = [{title: msg, detail: showWhoComponent}]
+
+    const condition = true //(ponerle un mejor nombre)
+
+    // Ícono
+    let checkResultIcon = inputInfo.length === 0
+    ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>
+    
+    if (!condition) {
+      checkResultIcon = <ErrorIcon color="error"/>
+    }
+
+    console.log("--- condition a pasar:", condition);
+    
+    // AUX: esto debe ir acá xq afuera del if no existen las variables que le estoy pasando
+    // Aux: Equipos incompletos no lleva set :)
+    return <AlgorithmPreCheck initialDescription={initialDescription} inputInfo={inputInfo} algorithm={"IncompleteTeams"}
+          msg={msg} showWhoList={inputInfo} showWhoComponent={showWhoComponent}
+          expandableData={expandableData} condition={true} checkResultIcon={checkResultIcon}
+          falseConditionMsg={"Dev error"} />
+  } else {
+    // AUX )cont): pero poner ese return en el if acá arriba, hace que acá solo haga return en vez de mostrar el
+    // spinner. Debería mostrar el spinner acá.
+    return;
+  }
+}
+
+export const DatesPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {
+  // Hay que pasarle esto.
+  // const falseConditionMsg = (<Typography component={"span"}>
+  //             <strong>Primero se debe cargar las fechas disponibles desde la sección {' '}</strong>
+  //           </Typography>
+  //           <Link
+  //             component="span"
+  //             onClick={() => setSelectedMenu("Disponibilidad fechas de Presentación")}
+  //             underline="always"
+  //             sx={{ color: "blue", cursor: "pointer", ml: 0.5}}
+  //             >
+  //             Disponibilidad fechas de Presentación
+  //           </Link>.)
+
+}

--- a/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
+++ b/src/components/Algorithms/SpecificAlgorithmsPreCheck.js
@@ -15,38 +15,41 @@ import AlgorithmPreCheck from "./AlgorithmPreCheck";
 
 // }
 
-export const IncompleteTeamsPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {
-  if (inputInfo) {
-    // A ESTE LO TRAIGO DE AFUERA:
-    // const preCheckMsg = `Este algoritmo utiliza las respuestas al formulario de equipos`+    
-    //     ` (Preferencias / Ya tengo tema y tutor) como input, para completar los equipos en base a sus preferencias.`
-    // ^ SE LLAMA INITIAL DESCRIPTION ACÁ, igual se puede traer para adentro dsp
+// getter auxiliar
+const getIcon = (list, externalCondition) => {
 
-    const studentsMsg = inputInfo.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
-    : inputInfo.length === 1 ? "Existe 1 estudiante que no está en respuestas al formulario de equipos en ninguna de sus variantes"
-    : `Existen ${inputInfo.length} estudiantes que no están en respuestas al formulario de equipos en ninguna de sus variantes`
-
-    const showWhoList = inputInfo;
-    const showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
-
-    const condition = true //(ponerle un mejor nombre)
-    
-    // Ícono
-    let checkResultIcon = inputInfo.length === 0
-    ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>    
-    if (!condition) {
-        checkResultIcon = <ErrorIcon color="error"/>
+    if (!externalCondition) {
+        return <ErrorIcon color="error"/>
     }
+    if (list.length === 0) {
+        return <CheckCircleIcon color="success"/>
+    }
+    if (list.length > 0) {
+        return <WarningAmberIcon color="warning"/>
+    }
+}
+
+export const IncompleteTeamsPreCheck = ({initialDescription, inputInfo}) => {
+  if (inputInfo) {    
+
+    const showWhoList = inputInfo; // por uniformidad / claridad con los demás casos
+    const showWhoComponent = <StudentsTable dataListToRender={showWhoList} />;
+    const studentsMsg = showWhoList.length === 0 ? "Todos/as los/as estudiantes forman parte de alguna respuesta al formulario."
+    : showWhoList.length === 1 ? "Existe 1 estudiante que no está en respuestas al formulario de equipos en ninguna de sus variantes"
+    : `Existen ${showWhoList.length} estudiantes que no están en respuestas al formulario de equipos en ninguna de sus variantes`
+
+    const externalCondition = true //    
+    const studentsIcon = getIcon(showWhoList, externalCondition);    
     
-    // los dos primeros campos se usan para el modal, pero el tercero se usa para ver su len y si debería renderizarse
-    const expandableData = [{title: studentsMsg, detail: showWhoComponent, infoList: showWhoList, icon: checkResultIcon}]
+    // Los dos primeros campos se usan para el modal, el tercero se usa para ver su len y si debería renderizarse el botón
+    const expandableData = [{title: studentsMsg, detail: showWhoComponent, infoList: showWhoList, icon: studentsIcon}]
     
-    // AUX: esto debe ir acá xq afuera del if no existen las variables que le estoy pasando
-    // Aux: Equipos incompletos no lleva set :)
-    return <AlgorithmPreCheck initialDescription={initialDescription}
-          expandableData={expandableData} condition={true} checkResultIcon={checkResultIcon}
-          //falseConditionMsg={"Dev error"}
-          />
+    return <AlgorithmPreCheck
+      initialDescription={initialDescription}
+      expandableData={expandableData}
+      condition={true}
+      checkResultIcon={studentsIcon}
+    />
   } else {
     // AUX )cont): pero poner ese return en el if acá arriba, hace que acá solo haga return en vez de mostrar el
     // spinner. Debería mostrar el spinner acá.
@@ -54,53 +57,37 @@ export const IncompleteTeamsPreCheck = ({initialDescription, inputInfo, algorith
   }
 }
 
-export const DatesPreCheck = ({initialDescription, inputInfo, algorithm, setSelectedMenu}) => {
+export const DatesPreCheck = ({inputInfo, setSelectedMenu}) => {
 
     if (inputInfo) {
+
+        const externalCondition = inputInfo.admin_slots;
         
-        const condition = inputInfo.admin_slots;
-        
+        ///// Equipos        
+        const showWhoTeamList = inputInfo.teams;
+        const showWhoTeamsComponent = <TeamsTable dataListToRender={showWhoTeamList} />;
         const teamsMsg =
-          inputInfo.teams?.length === 0 ? "Todos los equipos completaron su disponibilidad."
-          : inputInfo.teams?.length === 1 ? "Existe 1 equipo que no completó su disponibilidad"
-          : `Existen ${inputInfo.teams?.length} equipos que no completaron su disponibilidad`
+            showWhoTeamList?.length === 0 ? "Todos los equipos completaron su disponibilidad."
+          : showWhoTeamList?.length === 1 ? "Existe 1 equipo que no completó su disponibilidad"
+          : `Existen ${showWhoTeamList?.length} equipos que no completaron su disponibilidad`
+        const teamsIcon = getIcon(showWhoTeamList, externalCondition);        
         
-        const showWhoList = inputInfo.teams;
-        const showWhoComponent = <TeamsTable dataListToRender={showWhoList} />;
-
-        // Ícono
-        let checkResultIcon = inputInfo.length === 0
-        ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>        
-        if (!condition) {
-          checkResultIcon = <ErrorIcon color="error"/>
-        }
-
-        //////////
-        // Tutores
-        const showWhoTutorsList = inputInfo.teachers;
-        const showWhoTutorsComponent = <TutorsTable dataListToRender={showWhoTutorsList} />;      
+        ///// Tutores
+        const showWhoTutorList = inputInfo.teachers;
+        const showWhoTutorsComponent = <TutorsTable dataListToRender={showWhoTutorList} />;      
         const tutorsMsg = 
-          inputInfo.teachers?.length === 0 ? "Todos/as los/as tutores/as completaron su disponibilidad."
-          : inputInfo.teachers?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad"
-          : `Existen ${inputInfo.teachers?.length} tutores/as que no completaron su disponibilidad`      
-        // Ícono
-        let tutorsIcon = inputInfo.length === 0
-        ? <CheckCircleIcon color="success"/> : <WarningAmberIcon color="warning"/>        
-        if (!condition) {
-            tutorsIcon = <ErrorIcon color="error"/>
-        }
-
-
+            showWhoTutorList?.length === 0 ? "Todos/as los/as tutores/as completaron su disponibilidad."
+          : showWhoTutorList?.length === 1 ? "Existe 1 tutor/a que no completó su disponibilidad"
+          : `Existen ${showWhoTutorList?.length} tutores/as que no completaron su disponibilidad`              
+        const tutorsIcon = getIcon(showWhoTutorList, externalCondition);
         
-        // los dos primeros campos se usan para el modal, pero el tercero se usa para ver su len y si debería renderizarse
-        const expandableData = [{title: teamsMsg, detail: showWhoComponent, infoList: showWhoList, icon: checkResultIcon},
-                            {title: tutorsMsg, detail: showWhoTutorsComponent, infoList: showWhoTutorsList, icon: tutorsIcon}]
+        ///// Data
+        // Los dos primeros campos se usan para el modal, el tercero se usa para ver su len y si debería renderizarse el botón
+        const expandableData = [{title: teamsMsg, detail: showWhoTeamsComponent, infoList: showWhoTeamList, icon: teamsIcon},
+                            {title: tutorsMsg, detail: showWhoTutorsComponent, infoList: showWhoTutorList, icon: tutorsIcon}]
         if (!setSelectedMenu) return;
 
-
-
-
-        /////
+        ///// Mensaje a mostrar si admin no cargó las fechas
         const falseConditionMsg = (
             <>
                 <Typography component={"span"}>
@@ -116,14 +103,12 @@ export const DatesPreCheck = ({initialDescription, inputInfo, algorithm, setSele
                 </Link>.
             </>
         );
-
-        // AUX hay que ponerle un map para pasarle más de un msg... o algo así, ver.
         return <AlgorithmPreCheck
-          expandableData={expandableData} condition={condition} checkResultIcon={checkResultIcon}
-          falseConditionMsg={falseConditionMsg} />
+          expandableData={expandableData}
+          condition={externalCondition}
+          checkResultIcon={teamsIcon}
+          falseConditionMsg={falseConditionMsg}
+        />
     }
     
-
-   
-
 }

--- a/src/components/UI/Tables/ChildTables/GroupsTable.js
+++ b/src/components/UI/Tables/ChildTables/GroupsTable.js
@@ -2,7 +2,7 @@ import React from "react";
 import { useSelector } from "react-redux";
 import TeamDataTable from "../../../Algorithms/GroupDataTable";
 
-const TeamsTable = ({dataListToRender=[]}) => {
+const TeamsTable = ({dataListToRender = null}) => {
   const title = "Equipos";
   const period = useSelector((state) => state.period);
   const endpoint = `/groups/?period=${period.id}`;
@@ -12,10 +12,12 @@ const TeamsTable = ({dataListToRender=[]}) => {
   .map(({ version, rehydrated, ...rest }) => rest)
   .filter((item) => Object.keys(item).length > 0);
 
-  // Si tiene elementos, la estoy llamando para la Verificación previa a algoritmos,
-  // y no quiero que haga ningún fetch
-  if (!dataListToRender) return;  
-  if (dataListToRender.length > 0) {
+  // Caso prop no cargada aún
+  if (dataListToRender === undefined) return;
+
+  // Si le estoy pasando una dataListToRender, es que la estoy llamando para la Verificación previa
+  // a algoritmos, y no quiero que haga ningún fetch
+  if (dataListToRender !== null) {
     return (
           <TeamDataTable
             items={dataListToRender}
@@ -24,8 +26,8 @@ const TeamsTable = ({dataListToRender=[]}) => {
             enableFilterButtons={false}
           />
     );
-  } if (dataListToRender.length === 0) {
-    // Si está vacía, es el uso por defecto que ya existía, es para mostrar tabla de Estudiantes
+  } else {
+    // Si no le pasé nada, es el uso por defecto que ya existía, es para mostrar tabla de Estudiantes
     return (
       <TeamDataTable endpoint={endpoint} items={teams} title={title}/>
     );

--- a/src/components/UI/Tables/ChildTables/StudentsTable.js
+++ b/src/components/UI/Tables/ChildTables/StudentsTable.js
@@ -31,6 +31,8 @@ const StudentsTable = ({dataListToRender = null}) => {
     </>
   );
 
+  if (dataListToRender === undefined) return;
+
   // Si le estoy pasando una dataListToRender, es que la estoy llamando para la Verificación previa
   // a algoritmos, y no quiero que haga ningún fetch
   if (dataListToRender !== null) {

--- a/src/components/UI/Tables/ChildTables/StudentsTable.js
+++ b/src/components/UI/Tables/ChildTables/StudentsTable.js
@@ -4,7 +4,7 @@ import ParentTable from '../ParentTable';
 import { useSelector } from "react-redux";
 import { TableType } from '../TableType';
 
-const StudentsTable = ({dataListToRender = []}) => {
+const StudentsTable = ({dataListToRender = null}) => {
   // Este dataListToRender es opcional, para la pantalla de Estudiantes no se usa, pero
   // se agrega para poder pasarle una lista y no tener que llamar al endpoint
   const period = useSelector((state) => state.period);
@@ -31,9 +31,9 @@ const StudentsTable = ({dataListToRender = []}) => {
     </>
   );
 
-  // Si tiene elementos, la estoy llamando para la Verificación previa a algoritmos,
-  // y no quiero que haga ningún fetch
-  if (dataListToRender.length > 0) {
+  // Si le estoy pasando una dataListToRender, es que la estoy llamando para la Verificación previa
+  // a algoritmos, y no quiero que haga ningún fetch
+  if (dataListToRender !== null) {
     return (
       <ParentTable
         columns={columns} rowKeys={rowKeys} renderRow={renderRow}
@@ -45,7 +45,7 @@ const StudentsTable = ({dataListToRender = []}) => {
       />
     );
   } else {
-    // Si está vacía, es el uso por defecto que ya existía, es para mostrar tabla de Estudiantes
+    // Si no le pasé nada, es el uso por defecto que ya existía, es para mostrar tabla de Estudiantes
     return (
       <ParentTable title={title} columns={columns} rowKeys={rowKeys} endpoint={endpoint} renderRow={renderRow} items={students}/>
     );

--- a/src/components/UI/Tables/ChildTables/TutorsTable.js
+++ b/src/components/UI/Tables/ChildTables/TutorsTable.js
@@ -6,7 +6,7 @@ import { useSelector } from "react-redux";
 import { TableType } from '../TableType';
 import { addCapacityToTutors } from '../../../../utils/addCapacityToTutors';
 
-const TutorsTable = ({dataListToRender = []}) => {
+const TutorsTable = ({dataListToRender = null}) => {
   const { period } = useParams();
   const endpoint = `/tutors/periods/${period}`;
   const title = TableType.TUTORS;
@@ -41,10 +41,12 @@ const TutorsTable = ({dataListToRender = []}) => {
       <TableCell>{item.capacity}</TableCell>
     </>
   );
+
+  if (dataListToRender === undefined) return;
   
-  // Si tiene elementos, la estoy llamando para la Verificación previa a algoritmos,
-  // y no quiero que haga ningún fetch
-  if (dataListToRender.length > 0) {
+  // Si le estoy pasando una dataListToRender, es que la estoy llamando para la Verificación previa
+  // a algoritmos, y no quiero que haga ningún fetch
+  if (dataListToRender !== null) {
     return (
       <ParentTable
         columns={columns} rowKeys={rowKeys} renderRow={renderRow}
@@ -56,7 +58,7 @@ const TutorsTable = ({dataListToRender = []}) => {
       />
     );
   } else {
-    // Si está vacía, es el uso por defecto que ya existía, es para mostrar tabla de Estudiantes
+    // Si no le pasé nada, es el uso por defecto que ya existía, es para mostrar tabla de Estudiantes
     return (
       <ParentTable title={title} columns={columns} rowKeys={rowKeys} endpoint={endpoint} renderRow={renderRow} items={tutors}
                     csvColumns={csvColumns} csvRowKeys={csvRowKeys}/> // []

--- a/src/components/UI/Tables/ChildTables/TutorsTable.js
+++ b/src/components/UI/Tables/ChildTables/TutorsTable.js
@@ -6,7 +6,7 @@ import { useSelector } from "react-redux";
 import { TableType } from '../TableType';
 import { addCapacityToTutors } from '../../../../utils/addCapacityToTutors';
 
-const TutorsTable = () => {
+const TutorsTable = ({dataListToRender = []}) => {
   const { period } = useParams();
   const endpoint = `/tutors/periods/${period}`;
   const title = TableType.TUTORS;
@@ -41,10 +41,27 @@ const TutorsTable = () => {
       <TableCell>{item.capacity}</TableCell>
     </>
   );
-
-  return (
-    <ParentTable title={title} columns={columns} rowKeys={rowKeys} endpoint={endpoint} renderRow={renderRow} items={tutors} csvColumns={csvColumns} csvRowKeys={csvRowKeys}/>
-  );
+  
+  // Si tiene elementos, la estoy llamando para la Verificación previa a algoritmos,
+  // y no quiero que haga ningún fetch
+  if (dataListToRender.length > 0) {
+    return (
+      <ParentTable
+        columns={columns} rowKeys={rowKeys} renderRow={renderRow}
+        title={TableType.EMBEDDEDNOTITLE}
+        items={dataListToRender}
+        enableEdit={false}
+        enableDelete={false} // Consistencia con Verificación previa de equipos (no existe delete teams)
+        enableAdd={false}
+      />
+    );
+  } else {
+    // Si está vacía, es el uso por defecto que ya existía, es para mostrar tabla de Estudiantes
+    return (
+      <ParentTable title={title} columns={columns} rowKeys={rowKeys} endpoint={endpoint} renderRow={renderRow} items={tutors}
+                    csvColumns={csvColumns} csvRowKeys={csvRowKeys}/> // []
+    );
+  }
 };
 
 export default TutorsTable;


### PR DESCRIPTION
# Pre Check (Verificación previa) Parte 2

- refactor: en lugar de tener tanto ruido en un solo componente con variables sin definir para algún caso pero existiendo para que todo funcione, separo el AlgorithmPreCheck: ahora dos componentes nuevos (uno para fechas y uno para equipos incompletos) se encargan de crear las cosas que necesiten y al final sí llaman al AlgorithmPreCheck. Se refactoriza la manera en que se renderiza, también, para no copypastear tanto, y varios fixes pequeños sobre los íconos. Ahora el AlgorithmPreCheck es quien pone los íconos de lo que sea que reciba, para no tener que hacerlo afuera.

- feat: se agrega mostrar Tutores que no tienen disponiblidad, Para eso, la verificación previa ahora no muestra directamente la tabla sino solo el mensaje "Existen ... que no completaron su disponibilidad" y hay un botón de Analizar que abre un modal. En el modal se muestran todos los mensajes de ese estilo y se usa el esquema de Accordion (filas colapsables como en las páginas de FAQ), al expandir cada sección se ve la tabla con la gente con problemas.
- Se agregan iconitos de éxito / advertencia / error a los mensajes.

- para poder mostrar la tabla de tutores embebida, se hace un minor refactor, análogo a lo que ya se había hecho para students (se distingue caso tomá el endpoint y hacé fetch, de caso tomá lista y mostrá solo esto sin fetch). Además análisis más robusto de si estoy en uno u otro caso.

- se agrega spinner mientras cargan los datos para la Verificación Previa.